### PR TITLE
Improve class .jh-entity-details

### DIFF
--- a/generators/client/templates/vue/src/main/webapp/app/App.vue
+++ b/generators/client/templates/vue/src/main/webapp/app/App.vue
@@ -225,18 +225,27 @@ Bootstrap tweaks
     /* ==========================================================================
     entity detail page css
     ========================================================================== */
-    .row.jh-entity-details > dd {
-        margin-bottom: 15px;
+    .row.jh-entity-details {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        column-gap: 10px;
+        line-height: 1.5;
     }
 
     @media screen and (min-width: 768px) {
         .row.jh-entity-details > dt {
-            margin-bottom: 15px;
+            float: left;
+            overflow: hidden;
+            clear: left;
+            text-align: right;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            padding: 0.5em 0;
         }
 
         .row.jh-entity-details > dd {
             border-bottom: 1px solid #eee;
-            padding-left: 180px;
+            padding: 0.5em 0;
             margin-left: 0;
         }
     }

--- a/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-details.vue.ejs
+++ b/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-details.vue.ejs
@@ -3,9 +3,8 @@
         <div class="col-8">
             <div v-if="<%= entityInstance %>">
                 <h2><span v-text="$t('<%= i18nKeyPrefix %>.detail.title')"><%= entityAngularName %></span> {{<%= entityInstance %>.id}}</h2>
-                <hr>
                 <!--<jhi-alert-error></jhi-alert-error>-->
-                <dl class="row-md jh-entity-details">
+                <dl class="row jh-entity-details">
 
                     <%_ for (idx in fields) {
                         const fieldName = fields[idx].fieldName;


### PR DESCRIPTION
When i generate a new entity, it seems that we don't use the "jh-entity-details" because of the row-md class before -> class="row-md jh-entity-details".
And the presentation isn't beautiful.
So i tried to make it more sexy ! 
User management details use the same class.

Before :
![before_user_management_details](https://user-images.githubusercontent.com/13909948/48999342-a4d98380-f156-11e8-9585-550096f8a246.png)

After :
 ![user_management_details](https://user-images.githubusercontent.com/13909948/48999237-53c98f80-f156-11e8-9f2e-b83c046c1af0.png)

@jdubois, @deepu105 We have the same template in angular and maybe react so do you want me to do the same ?
