### PR TITLE
Add NPM test

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,9 @@
 {
     "env": {
         "node": true,
-        "es6": true
+        "es6": true,
+        "jasmine": true,
+        "mocha": true
     },
     "extends": ["airbnb-base"],
     "parserOptions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -251,7 +251,7 @@
     },
     "axios": {
       "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
         "follow-redirects": "^1.3.0",
@@ -1176,7 +1176,7 @@
     },
     "enabled": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "requires": {
         "env-variable": "0.0.x"
@@ -1757,7 +1757,7 @@
     },
     "fecha": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "resolved": "http://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
     "figures": {
@@ -1828,9 +1828,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
-      "integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
         "debug": "=3.1.0"
       }
@@ -1903,9 +1903,9 @@
       }
     },
     "generator-jhipster": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/generator-jhipster/-/generator-jhipster-5.5.0.tgz",
-      "integrity": "sha512-3PRUS1hPPw7anrX71XmrFBtSi3fNtC3iqJHVOZlYgSC2iOHPnTvOC09GIhNMjGK8pSdAyqUEAL4ZXD8EI77PYQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/generator-jhipster/-/generator-jhipster-5.7.0.tgz",
+      "integrity": "sha512-VT5yHTt53AnKSu5uOfI9usXY1sbUhdG3hEM9E5dnay2sNQFkiGgjH5uYR9yhjhgIyNM2Ao+7yS3z8MCR17IQVQ==",
       "requires": {
         "axios": "0.18.0",
         "chalk": "2.4.1",
@@ -1916,7 +1916,7 @@
         "glob": "7.1.2",
         "gulp-filter": "5.1.0",
         "insight": "0.10.1",
-        "jhipster-core": "3.4.0",
+        "jhipster-core": "3.6.7",
         "js-object-pretty-print": "0.3.0",
         "js-yaml": "3.12.0",
         "lodash": "4.17.10",
@@ -1957,9 +1957,9 @@
           }
         },
         "fs-extra": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
-          "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^4.0.0",
@@ -1967,12 +1967,12 @@
           }
         },
         "jhipster-core": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/jhipster-core/-/jhipster-core-3.4.0.tgz",
-          "integrity": "sha512-iVJ6MF4jlpvtVL5gbn9t4Jw27RodjY04SXYSGfTLAzHyQRMmehHLvNq/3DBjVwHgBrDn1u2k17oLGouJus9MhA==",
+          "version": "3.6.7",
+          "resolved": "https://registry.npmjs.org/jhipster-core/-/jhipster-core-3.6.7.tgz",
+          "integrity": "sha512-fLr62052D96jDomCIdGou7x3e2izdf3kcZ5ewfr4yrc/5ySRhbW/BnnEiAK8mxkq2bSKh614ZaQ2vDlDgtSPvA==",
           "requires": {
             "chevrotain": "4.1.0",
-            "fs-extra": "7.0.0",
+            "fs-extra": "7.0.1",
             "lodash": "4.17.11",
             "winston": "3.1.0"
           },
@@ -1995,7 +1995,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "p-limit": {
@@ -2995,12 +2995,12 @@
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
     },
     "lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.4.tgz",
+      "integrity": "sha512-EPstzZ23znHUVLKj+lcXO1KvZkrlw+ZirdwvOmnAnA/1PB4ggyXJ77LRkCqkff+ShQ+cqoxCxLQOh4cKITO5iA==",
       "requires": {
         "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "yallist": "^3.0.2"
       }
     },
     "macos-release": {
@@ -3397,7 +3397,7 @@
     },
     "npmlog": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
       "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
       "requires": {
         "ansi": "~0.3.1",
@@ -4542,7 +4542,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-indent": {
@@ -4635,7 +4635,7 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
           "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
         },
         "ansi-regex": {
@@ -5300,9 +5300,9 @@
       "dev": true
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
     },
     "yargs": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "chalk": "2.4.1",
     "ejs": "2.6.1",
     "eslint-config-airbnb": "^17.1.0",
-    "generator-jhipster": ">=5.5.0",
+    "generator-jhipster": ">=5.7.0",
     "glob": "7.1.2",
     "gulp-filter": "5.1.0",
     "insight": "0.10.1",

--- a/test-integration/scripts/10-install-jhipster-vuejs.sh
+++ b/test-integration/scripts/10-install-jhipster-vuejs.sh
@@ -85,13 +85,17 @@ cp "$JHI_CLONED"/test-integration/scripts/00-init-env.sh "$JHI_HOME"/test-integr
 cp -R "$JHI_CLONED"/test-integration/samples-vuejs/* "$JHI_HOME"/test-integration/samples/
 
 #-------------------------------------------------------------------------------
+# Install yeoman
+#-------------------------------------------------------------------------------
+npm install -g yo
+
+#-------------------------------------------------------------------------------
 # Install JHipster Vuejs
 #-------------------------------------------------------------------------------
 cd "$JHI_CLONED"/
 npm ci
 npm link
 npm link generator-jhipster
-
 ls -al /home/travis/.nvm/versions/node/v10.13.0/lib/node_modules/
 
 npm run lint

--- a/test-integration/scripts/10-install-jhipster-vuejs.sh
+++ b/test-integration/scripts/10-install-jhipster-vuejs.sh
@@ -49,7 +49,7 @@ if [[ "$JHI_REPO" == *"/generator-jhipster" ]]; then
     git --no-pager log -n 10 --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
 
     npm ci
-    npm install -g "$JHI_HOME"
+    npm link
     if [[ "$JHI_APP" == "" || "$JHI_APP" == "ngx-default" ]]; then
         npm test
     fi

--- a/test-integration/scripts/10-install-jhipster-vuejs.sh
+++ b/test-integration/scripts/10-install-jhipster-vuejs.sh
@@ -92,6 +92,8 @@ npm ci
 npm link
 npm link generator-jhipster
 
+ls -al /home/travis/.nvm/versions/node/v10.13.0/lib/node_modules/
+
 npm run lint
 if [[ "$JHI_APP" == "" || "$JHI_APP" == "vuejs-default" ]]; then
     npm test

--- a/test-integration/scripts/10-install-jhipster-vuejs.sh
+++ b/test-integration/scripts/10-install-jhipster-vuejs.sh
@@ -93,4 +93,6 @@ npm link
 npm link generator-jhipster
 
 npm run lint
-# npm test
+if [[ "$JHI_APP" == "" || "$JHI_APP" == "vuejs-default" ]]; then
+    npm test
+fi

--- a/test/client.spec.js
+++ b/test/client.spec.js
@@ -1,0 +1,88 @@
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const constants = require('generator-jhipster/generators/generator-constants');
+const VueJSClientGenerator = require('../generators/client/index');
+
+const CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
+
+const expectedFiles = {
+    i18nJson: [
+        `${CLIENT_MAIN_SRC_DIR}i18n/en/activate.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/en/audits.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/en/configuration.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/en/error.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/en/global.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/en/health.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/en/login.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/en/logs.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/en/home.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/en/metrics.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/en/password.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/en/register.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/en/sessions.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/en/settings.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/en/reset.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/en/user-management.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/fr/activate.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/fr/audits.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/fr/configuration.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/fr/error.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/fr/global.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/fr/health.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/fr/login.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/fr/logs.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/fr/home.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/fr/metrics.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/fr/password.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/fr/register.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/fr/sessions.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/fr/settings.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/fr/reset.json`,
+        `${CLIENT_MAIN_SRC_DIR}i18n/fr/user-management.json`
+    ]
+};
+
+describe('JHipster client generator with blueprint', () => {
+    const blueprintNames = ['generator-jhipster-vuejs', 'vuejs'];
+
+
+    blueprintNames.forEach((blueprintName) => {
+        describe(`generate client with blueprint option '${blueprintName}'`, () => {
+            before((done) => {
+                helpers
+                    .run(path.join(__dirname, '../node_modules/generator-jhipster/generators/client'))
+                    .withOptions({
+                        'from-cli': true,
+                        build: 'gradle',
+                        auth: 'jwt',
+                        db: 'mysql',
+                        skipInstall: true,
+                        blueprint: blueprintName,
+                        skipChecks: true
+                    })
+                    .withGenerators([[VueJSClientGenerator, 'jhipster-vuejs:client']])
+                    .withPrompts({
+                        baseName: 'jhipster',
+                        clientFramework: 'VueJS',
+                        useSass: false,
+                        enableTranslation: true,
+                        nativeLanguage: 'en',
+                        languages: ['fr']
+                    })
+                    .on('end', done());
+            });
+
+            it('creates expected files from jhipster client generator', () => {
+                // assert.file(expectedFiles.client);
+                assert.file(expectedFiles.i18nJson);
+            });
+
+            it('contains the specific change added by the blueprint', () => {
+                assert.fileContent('package.json', '"vue"');
+                assert.fileContent('package.json', '"vuex"');
+                assert.fileContent('package.json', '"vuelidate"');
+            });
+        });
+    });
+});

--- a/test/client.spec.js
+++ b/test/client.spec.js
@@ -2,9 +2,10 @@ const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');
 const constants = require('generator-jhipster/generators/generator-constants');
-const VueJSClientGenerator = require('../generators/client/index');
 
 const CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
+const CLIENT_TEST_SRC_DIR = constants.CLIENT_TEST_SRC_DIR;
+const CLIENT_WEBPACK_DIR = constants.CLIENT_WEBPACK_DIR;
 
 const expectedFiles = {
     i18nJson: [
@@ -40,49 +41,296 @@ const expectedFiles = {
         `${CLIENT_MAIN_SRC_DIR}i18n/fr/settings.json`,
         `${CLIENT_MAIN_SRC_DIR}i18n/fr/reset.json`,
         `${CLIENT_MAIN_SRC_DIR}i18n/fr/user-management.json`
+    ],
+
+    app: [
+        `${CLIENT_MAIN_SRC_DIR}app/components/account/change-password/ChangePassword.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/account/change-password/ChangePassword.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/account/login-form/LoginForm.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/account/login-form/LoginForm.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/account/register/Register.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/account/register/Register.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/account/reset-password/ResetPassword.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/account/reset-password/ResetPassword.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/account/sessions/Sessions.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/account/sessions/Sessions.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/account/settings/Settings.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/account/settings/Settings.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/account/LoginModalService.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/account/Principal.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/account/RegisterService.vue`,
+
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/audits/Audits.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/audits/AuditsService.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/configuration/Configuration.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/configuration/Configuration.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/configuration/ConfigurationService.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/docs/Docs.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/docs/Docs.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/health/Health.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/health/Health.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/health/HealthModal.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/health/HealthService.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/logs/Logs.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/logs/LogsService.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/metrics/Metrics.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/metrics/Metrics.modal.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/metrics/Metrics.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/metrics/MetricsModal.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/metrics/MetricsService.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/user-management/UserManagement.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/user-management/UserManagement.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/user-management/UserManagementEdit.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/user-management/UserManagementEdit.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/user-management/UserManagementService.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/user-management/UserManagementView.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/admin/user-management/UserManagementView.vue`,
+
+        `${CLIENT_MAIN_SRC_DIR}app/components/home/Home.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/home/Home.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/jhi-footer/JhiFooter.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/jhi-footer/JhiFooter.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/jhi-navbar/JhiNavbar.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/jhi-navbar/JhiNavbar.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/ribbon/Ribbon.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/components/ribbon/Ribbon.vue`,
+
+        `${CLIENT_MAIN_SRC_DIR}app/config/axios-interceptor.ts`,
+
+        `${CLIENT_MAIN_SRC_DIR}app/entities/user/user.service.vue`,
+
+        `${CLIENT_MAIN_SRC_DIR}app/locale/LanguageService.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/locale/TranslationService.vue`,
+
+        `${CLIENT_MAIN_SRC_DIR}app/router/index.ts`,
+
+        `${CLIENT_MAIN_SRC_DIR}app/shared/data/DataUtilsService.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/shared/date/filters.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/shared/config.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/shared/ItemCount.vue`,
+
+        `${CLIENT_MAIN_SRC_DIR}app/App.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/App.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/constants.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/main.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/shims-vue.d.ts`
+    ],
+
+    test: [
+        // `${CLIENT_TEST_SRC_DIR}jest.conf.js`,
+    ],
+
+    protractor: [
+        `${CLIENT_TEST_SRC_DIR}e2e/modules/account/account.spec.ts`,
+        `${CLIENT_TEST_SRC_DIR}e2e/modules/administration/administration.spec.ts`,
+        `${CLIENT_TEST_SRC_DIR}e2e/page-objects/base-component.ts`,
+        `${CLIENT_TEST_SRC_DIR}e2e/page-objects/navbar-page.ts`,
+        `${CLIENT_TEST_SRC_DIR}e2e/page-objects/password-page.ts`,
+        `${CLIENT_TEST_SRC_DIR}e2e/page-objects/register-page.ts`,
+        `${CLIENT_TEST_SRC_DIR}e2e/page-objects/settings-page.ts`,
+        `${CLIENT_TEST_SRC_DIR}e2e/page-objects/signin-page.ts`,
+        `${CLIENT_TEST_SRC_DIR}e2e/util/utils.ts`,
+        `${CLIENT_TEST_SRC_DIR}protractor.conf.js`
+    ],
+
+    webpack: [
+        `${CLIENT_WEBPACK_DIR}/loader.conf.js`,
+        `${CLIENT_WEBPACK_DIR}/utils.js`,
+        `${CLIENT_WEBPACK_DIR}/vue.utils.js`,
+        `${CLIENT_WEBPACK_DIR}/webpack.common.js`,
+        `${CLIENT_WEBPACK_DIR}/webpack.dev.js`,
+        `${CLIENT_WEBPACK_DIR}/webpack.prod.js`
     ]
 };
 
-describe('JHipster client generator with blueprint', () => {
-    const blueprintNames = ['generator-jhipster-vuejs', 'vuejs'];
-
-
-    blueprintNames.forEach((blueprintName) => {
-        describe(`generate client with blueprint option '${blueprintName}'`, () => {
-            before((done) => {
-                helpers
-                    .run(path.join(__dirname, '../node_modules/generator-jhipster/generators/client'))
-                    .withOptions({
-                        'from-cli': true,
-                        build: 'gradle',
-                        auth: 'jwt',
-                        db: 'mysql',
-                        skipInstall: true,
-                        blueprint: blueprintName,
-                        skipChecks: true
-                    })
-                    .withGenerators([[VueJSClientGenerator, 'jhipster-vuejs:client']])
-                    .withPrompts({
-                        baseName: 'jhipster',
-                        clientFramework: 'VueJS',
-                        useSass: false,
-                        enableTranslation: true,
-                        nativeLanguage: 'en',
-                        languages: ['fr']
-                    })
-                    .on('end', done());
-            });
-
-            it('creates expected files from jhipster client generator', () => {
-                // assert.file(expectedFiles.client);
-                assert.file(expectedFiles.i18nJson);
-            });
-
-            it('contains the specific change added by the blueprint', () => {
-                assert.fileContent('package.json', '"vue"');
-                assert.fileContent('package.json', '"vuex"');
-                assert.fileContent('package.json', '"vuelidate"');
-            });
+describe('VueJS JHipster blueprint', () => {
+    describe('Default with Maven', () => {
+        before((done) => {
+            helpers
+                .run('generator-jhipster/generators/app')
+                .withOptions({
+                    'from-cli': true,
+                    skipInstall: true,
+                    blueprint: 'vuejs',
+                    skipChecks: true
+                })
+                .withGenerators([
+                    [
+                        require('../generators/client/index.js'), // eslint-disable-line global-require
+                        'jhipster-vuejs:client',
+                        path.join(__dirname, '../generators/client/index.js')
+                    ]
+                ])
+                .withPrompts({
+                    baseName: 'sampleMysql',
+                    packageName: 'com.mycompany.myapp',
+                    applicationType: 'monolith',
+                    databaseType: 'sql',
+                    devDatabaseType: 'h2Disk',
+                    prodDatabaseType: 'mysql',
+                    cacheProvider: 'ehcache',
+                    authenticationType: 'jwt',
+                    enableTranslation: true,
+                    nativeLanguage: 'en',
+                    languages: ['en', 'fr'],
+                    buildTool: 'maven',
+                    clientFramework: 'VueJS'
+                })
+                .on('end', done);
+        });
+        it('creates expected files from jhipster client generator', () => {
+            assert.file(expectedFiles.i18nJson);
+            assert.file(expectedFiles.app);
+            assert.file(expectedFiles.test);
+            assert.noFile(expectedFiles.protractor);
+            assert.file(expectedFiles.webpack);
+        });
+        it('contains the specific change added by the blueprint', () => {
+            assert.fileContent('package.json', '"vue"');
+            assert.fileContent('package.json', '"vuex"');
+            assert.fileContent('package.json', '"vuelidate"');
+        });
+    });
+    describe('Default with Gradle', () => {
+        before((done) => {
+            helpers
+                .run('generator-jhipster/generators/app')
+                .withOptions({
+                    'from-cli': true,
+                    skipInstall: true,
+                    blueprint: 'vuejs',
+                    skipChecks: true
+                })
+                .withGenerators([
+                    [
+                        require('../generators/client/index.js'), // eslint-disable-line global-require
+                        'jhipster-vuejs:client',
+                        path.join(__dirname, '../generators/client/index.js')
+                    ]
+                ])
+                .withPrompts({
+                    baseName: 'sampleMysql',
+                    packageName: 'com.mycompany.myapp',
+                    applicationType: 'monolith',
+                    databaseType: 'sql',
+                    devDatabaseType: 'h2Disk',
+                    prodDatabaseType: 'mysql',
+                    cacheProvider: 'ehcache',
+                    authenticationType: 'jwt',
+                    enableTranslation: true,
+                    nativeLanguage: 'en',
+                    languages: ['en', 'fr'],
+                    buildTool: 'gradle',
+                    clientFramework: 'VueJS'
+                })
+                .on('end', done);
+        });
+        it('creates expected files from jhipster client generator', () => {
+            assert.file(expectedFiles.i18nJson);
+            assert.file(expectedFiles.app);
+            assert.file(expectedFiles.test);
+            assert.noFile(expectedFiles.protractor);
+            assert.file(expectedFiles.webpack);
+        });
+        it('contains the specific change added by the blueprint', () => {
+            assert.fileContent('package.json', '"vue"');
+            assert.fileContent('package.json', '"vuex"');
+            assert.fileContent('package.json', '"vuelidate"');
+        });
+    });
+    describe('noi18n with Maven', () => {
+        before((done) => {
+            helpers
+                .run('generator-jhipster/generators/app')
+                .withOptions({
+                    'from-cli': true,
+                    skipInstall: true,
+                    blueprint: 'vuejs',
+                    skipChecks: true
+                })
+                .withGenerators([
+                    [
+                        require('../generators/client/index.js'), // eslint-disable-line global-require
+                        'jhipster-vuejs:client',
+                        path.join(__dirname, '../generators/client/index.js')
+                    ]
+                ])
+                .withPrompts({
+                    baseName: 'sampleMysql',
+                    packageName: 'com.mycompany.myapp',
+                    applicationType: 'monolith',
+                    databaseType: 'sql',
+                    devDatabaseType: 'h2Disk',
+                    prodDatabaseType: 'mysql',
+                    cacheProvider: 'ehcache',
+                    authenticationType: 'jwt',
+                    enableTranslation: false,
+                    nativeLanguage: 'en',
+                    buildTool: 'maven',
+                    clientFramework: 'VueJS'
+                })
+                .on('end', done);
+        });
+        it('creates expected files from jhipster client generator', () => {
+            assert.noFile(expectedFiles.i18nJson);
+            assert.file(expectedFiles.app);
+            assert.file(expectedFiles.test);
+            assert.noFile(expectedFiles.protractor);
+            assert.file(expectedFiles.webpack);
+        });
+        it('contains the specific change added by the blueprint', () => {
+            assert.fileContent('package.json', '"vue"');
+            assert.fileContent('package.json', '"vuex"');
+            assert.fileContent('package.json', '"vuelidate"');
+        });
+    });
+    describe('Elasticsearch and Protractor', () => {
+        before((done) => {
+            helpers
+                .run('generator-jhipster/generators/app')
+                .withOptions({
+                    'from-cli': true,
+                    skipInstall: true,
+                    blueprint: 'vuejs',
+                    skipChecks: true
+                })
+                .withGenerators([
+                    [
+                        require('../generators/client/index.js'), // eslint-disable-line global-require
+                        'jhipster-vuejs:client',
+                        path.join(__dirname, '../generators/client/index.js')
+                    ]
+                ])
+                .withPrompts({
+                    baseName: 'sampleMysql',
+                    packageName: 'com.mycompany.myapp',
+                    applicationType: 'monolith',
+                    databaseType: 'sql',
+                    devDatabaseType: 'h2Disk',
+                    prodDatabaseType: 'mysql',
+                    cacheProvider: 'ehcache',
+                    authenticationType: 'jwt',
+                    searchEngine: 'elasticsearch',
+                    enableTranslation: true,
+                    nativeLanguage: 'en',
+                    languages: ['en', 'fr'],
+                    testFrameworks: ['protractor'],
+                    buildTool: 'maven',
+                    clientFramework: 'VueJS'
+                })
+                .on('end', done);
+        });
+        it('creates expected files from jhipster client generator', () => {
+            assert.file(expectedFiles.i18nJson);
+            assert.file(expectedFiles.app);
+            assert.file(expectedFiles.test);
+            assert.file(expectedFiles.protractor);
+            assert.file(expectedFiles.webpack);
+        });
+        it('contains the specific change added by the blueprint', () => {
+            assert.fileContent('package.json', '"vue"');
+            assert.fileContent('package.json', '"vuex"');
+            assert.fileContent('package.json', '"vuelidate"');
         });
     });
 });


### PR DESCRIPTION
Fix https://github.com/jhipster/jhipster-vuejs/issues/12

The `npm test` is launched only during the build for `vuejs-default`, because it is useless to launch these tests in each builds of the matrix.

```
  VueJS JHipster blueprint
    Default with Maven
      ✓ creates expected files from jhipster client generator (1ms)
      ✓ contains the specific change added by the blueprint (1ms)
    Default with Gradle
      ✓ creates expected files from jhipster client generator
      ✓ contains the specific change added by the blueprint
    noi18n with Maven
      ✓ creates expected files from jhipster client generator (2ms)
      ✓ contains the specific change added by the blueprint (1ms)
    Elasticsearch and Protractor
      ✓ creates expected files from jhipster client generator (1ms)
      ✓ contains the specific change added by the blueprint
```

I didn't add tests files yet, as I will open a new issue about that.
