### PR TITLE
add missing fa icons to icon lib

### DIFF
--- a/generators/client/templates/vue/src/main/webapp/app/shared/config.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/shared/config.ts.ejs
@@ -35,6 +35,8 @@ import { faTimesCircle } from '@fortawesome/free-solid-svg-icons/faTimesCircle';
 import { faSearch } from '@fortawesome/free-solid-svg-icons/faSearch';
 import { faRoad } from '@fortawesome/free-solid-svg-icons/faRoad';
 import { faCloud } from '@fortawesome/free-solid-svg-icons/faCloud';
+import { faBars } from '@fortawesome/free-solid-svg-icons/faBars';
+import { faTimes} from '@fortawesome/free-solid-svg-icons/faTimes';
 
 import VueCookie from 'vue-cookie';
 import Vuelidate from 'vuelidate';
@@ -83,7 +85,9 @@ export function initBootstrapVue(vue) {
     faRoad,
     faCloud,
     faTimesCircle,
-    faSearch
+    faSearch,
+    faBars,
+    faTimes
   );
 }
 


### PR DESCRIPTION
The additional two icons are required when logging in (where not in the react icon lib, seems there we use different icons).