### PR TITLE
add activation component for new accounts

### DIFF
--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -196,7 +196,10 @@ const vueFiles = {
                 'account/reset-password/reset-password.vue',
                 'account/reset-password/reset-password.component.ts',
                 'account/settings/settings.vue',
-                'account/settings/settings.component.ts'
+                'account/settings/settings.component.ts',
+                'account/activate/activate.component.ts',
+                'account/activate/activate.service.ts',
+                'account/activate/activate.vue'
             ]
         },
         {

--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -376,6 +376,7 @@ function writeFiles() {
             'app/core/ribbon/ribbon.vue',
             'app/shared/jhi-item-count.vue',
             'app/account/change-password/change-password.vue',
+            'app/account/activate/activate.vue',
             'app/account/login-form/login-form.vue',
             'app/account/register/register.vue',
             'app/account/reset-password/reset-password.vue',

--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -302,7 +302,8 @@ const vueFiles = {
                 'spec/app/account/change-password/change-password.component.spec.ts',
                 'spec/app/account/login-form/login-form.component.spec.ts',
                 'spec/app/account/reset-password/reset-password.component.spec.ts',
-                'spec/app/account/settings/settings.component.spec.ts'
+                'spec/app/account/settings/settings.component.spec.ts',
+                'spec/app/account/activate/activate.component.spec.ts'
             ]
         },
         {

--- a/generators/client/templates/vue/src/main/webapp/app/account/activate/activate.component.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/account/activate/activate.component.ts.ejs
@@ -7,8 +7,8 @@ import ActivateService from './activate.service';
 export default class Activate extends Vue {
   @Inject('activateService') private activateService: () => ActivateService;
   @Inject('loginModalService') private loginModalService: () => LoginModalService;
-  private success: boolean = false;
-  private error: boolean = false;
+  success: boolean = false;
+  error: boolean = false;
 
   beforeRouteEnter(to, from, next) {
     next(vm => {

--- a/generators/client/templates/vue/src/main/webapp/app/account/activate/activate.component.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/account/activate/activate.component.ts.ejs
@@ -1,0 +1,35 @@
+import Component from 'vue-class-component';
+import { Vue, Inject } from 'vue-property-decorator';
+import LoginModalService from '@/account/login-modal.service';
+import ActivateService from './activate.service';
+
+@Component
+export default class Activate extends Vue {
+  @Inject('activateService') private activateService: () => ActivateService;
+  @Inject('loginModalService') private loginModalService: () => LoginModalService;
+  private success: boolean = false;
+  private error: boolean = false;
+
+  beforeRouteEnter(to, from, next) {
+    next(vm => {
+        if (to.query.key) {
+          vm.init(to.query.key);
+         }
+      });
+    }
+
+  public init(key: string): void {
+      this.activateService().activateAccount(key)
+      .then(res => {
+          this.success = true;
+          this.error = false;
+      }, err => {
+          this.error = true;
+          this.success = false;
+      })
+  }
+
+  public openLogin(): void {
+      this.loginModalService().openLogin((<any>this).$root);
+  }
+}

--- a/generators/client/templates/vue/src/main/webapp/app/account/activate/activate.service.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/account/activate/activate.service.ts.ejs
@@ -1,0 +1,13 @@
+import axios, { AxiosInstance } from 'axios';
+
+export default class ActivateService {
+  private axios: AxiosInstance;
+
+  constructor() {
+    this.axios = axios;
+  }
+
+  public activateAccount(key: string): Promise<any> {
+    return this.axios.get(`api/activate?key=${key}`);
+  }
+}

--- a/generators/client/templates/vue/src/main/webapp/app/account/activate/activate.vue.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/account/activate/activate.vue.ejs
@@ -1,0 +1,19 @@
+<template>
+<div>
+  <div class="row justify-content-center">
+      <div class="col-md-8">
+          <h1 v-text="$t('activate.title')">Activation</h1>
+          <div class="alert alert-success" v-if="success">
+              <span v-html="$t('activate.messages.success')"><strong>Your user account has been activated.</strong> Please </span>
+              <a class="alert-link" v-on:click="openLogin" v-text="$t('global.messages.info.authenticated.link')">sign in</a>.
+          </div>
+          <div class="alert alert-danger" v-if="error" v-html="$t('activate.messages.error')">
+              <strong>Your user could not be activated.</strong> Please use the registration form to sign up.
+          </div>
+      </div>
+  </div>
+</div>
+</template>
+
+<script lang="ts" src="./activate.component.ts">
+</script>

--- a/generators/client/templates/vue/src/main/webapp/app/main.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/main.ts.ejs
@@ -7,6 +7,7 @@ import router from './router';
 import * as config from './shared/config/config';
 import * as bootstrapVueConfig from './shared/config/config-bootstrap-vue';
 import JhiItemCountComponent from './shared/jhi-item-count.vue';
+import ActivateService from './account/activate/activate.service';
 import AuditsService from './admin/audits/audits.service';
 import HealthService from './admin/health/health.service';
 import LoginModalService from './account/login-modal.service';
@@ -40,6 +41,7 @@ Vue.config.productionTip = false;
 const i18n = config.initI18N(Vue);
 <%_ } _%>
 const store = config.initVueXStore(Vue);
+
 const alertService = new AlertService(store);
 <%_ if (enableTranslation) { _%>
 const translationService = new TranslationService(store);
@@ -50,6 +52,7 @@ bootstrapVueConfig.initBootstrapVue(Vue);
 Vue.component('font-awesome-icon', FontAwesomeIcon);
 Vue.component('jhi-item-count', JhiItemCountComponent);
 
+const activateService = new ActivateService();
 const auditsService = new AuditsService();
 const healthService = new HealthService();
 const loginModalService = new LoginModalService();
@@ -75,6 +78,7 @@ new Vue({
   template: '<App/>',
   router,
   provide: {
+    activateService: () => activateService,
     auditsService: () => auditsService,
     healthService: () => healthService,
     loginModalService: () => loginModalService,

--- a/generators/client/templates/vue/src/main/webapp/app/router/index.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/router/index.ts.ejs
@@ -8,6 +8,7 @@ Component.registerHooks([
 import Router from 'vue-router';
 const Home = () => import('../core/home/home.vue');
 const Register = () => import('../account/register/register.vue');
+const Activate = () => import('../account/activate/activate.vue');
 const ResetPassword = () => import('../account/reset-password/reset-password.vue');
 const ChangePassword = () => import('../account/change-password/change-password.vue');
 <%_ if (authenticationType === 'session') { _%>
@@ -44,6 +45,11 @@ export default new Router({
       path: '/register',
       name: 'Register',
       component: Register
+    },
+    {
+      path: '/activate',
+      name: 'Activate',
+      component: Activate
     },
     {
       path: '/resetPassword',

--- a/generators/client/templates/vue/src/test/javascript/spec/app/account/activate/activate.component.spec.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/spec/app/account/activate/activate.component.spec.ts.ejs
@@ -1,0 +1,71 @@
+import { shallowMount, createLocalVue, Wrapper } from '@vue/test-utils';
+import axios from 'axios';
+
+import * as config from '@/shared/config/config';
+import Activate from '@/account/activate/activate.vue';
+import ActivateClass from '@/account/activate/activate.component';
+import ActivateService from '@/account/activate/activate.service';
+import LoginModalService from '@/account/login-modal.service';
+
+const localVue = createLocalVue();
+const mockedAxios: any = axios;
+
+config.initVueApp(localVue);
+<%_ if (enableTranslation) { _%>
+const i18n = config.initI18N(localVue);
+<%_ } _%>
+const store = config.initVueXStore(localVue);
+
+jest.mock('axios', () => ({
+  get: jest.fn(),
+  post: jest.fn()
+}));
+
+describe('Activate Component', () => {
+
+  let wrapper: Wrapper<ActivateClass>;
+  let activate: ActivateClass;
+
+  beforeEach(() => {
+    mockedAxios.get.mockReset();
+    mockedAxios.get.mockReturnValue(Promise.resolve({}));
+
+    wrapper = shallowMount<ActivateClass>(Activate, {
+      <%_ if (enableTranslation) { _%>
+      i18n,
+      <%_ } _%>
+      localVue,
+      provide: {
+        activateService: () => new ActivateService(),
+        loginModalService: () => new LoginModalService()
+      }
+    });
+    activate = wrapper.vm;
+  });
+
+  it('should be a Vue instance', () => {
+    expect(wrapper.isVueInstance()).toBeTruthy();
+  });
+
+  it('should display error when activation fails', async () => {
+
+    mockedAxios.get.mockReturnValue(Promise.reject({}));
+    activate.init('invalid-key');
+    await activate.$nextTick();
+
+    expect(activate.error).toBeTruthy();
+    expect(activate.success).toBeFalsy();
+  });
+
+  it('should display success when activation succeeds', async () => {
+
+    mockedAxios.get.mockReturnValue(Promise.resolve({}));
+
+    activate.init('valid-key');
+    await activate.$nextTick();
+
+    expect(activate.error).toBeFalsy();
+    expect(activate.success).toBeTruthy();
+  });
+});
+

--- a/test/client.spec.js
+++ b/test/client.spec.js
@@ -50,6 +50,9 @@ const expectedFiles = {
         `${CLIENT_MAIN_SRC_DIR}app/account/change-password/change-password.vue`,
         `${CLIENT_MAIN_SRC_DIR}app/account/login-form/login-form.component.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/account/login-form/login-form.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/account/activate/activate.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/account/activate/activate.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/account/activate/activate.service.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/account/register/register.component.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/account/register/register.vue`,
         `${CLIENT_MAIN_SRC_DIR}app/account/register/register.service.ts`,
@@ -62,6 +65,7 @@ const expectedFiles = {
 
         `${CLIENT_SPEC_SRC_DIR}app/account/change-password/change-password.component.spec.ts`,
         `${CLIENT_SPEC_SRC_DIR}app/account/login-form/login-form.component.spec.ts`,
+        `${CLIENT_SPEC_SRC_DIR}app/account/activate/activate.component.spec.ts`,
         // `${CLIENT_SPEC_SRC_DIR}app/account/register/register.component.spec.ts`,
         // `${CLIENT_SPEC_SRC_DIR}app/account/register/register.service.spec.ts`,
         // `${CLIENT_SPEC_SRC_DIR}app/account/reset-password/reset-password.component.spec.ts`,


### PR DESCRIPTION
To which page should we forward the user after successful activation and login? Currently the users stays on the activation page, which feels kind of strange. 

~~Edit: Currently the login modal always stays on the current page (without reloading it). Will open an issue for that, so we can go forward with this.~~ Will be handled most likely in https://github.com/jhipster/jhipster-vuejs/issues/185

~~Edit2: And tests are still missing, will track them too in #175~~ :heavy_check_mark:  

closes #149

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-vuejs/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-vuejs/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
