### PR TITLE
add forbidden route

### DIFF
--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -163,6 +163,8 @@ const vueFiles = {
             templates: [
                 'core/home/home.vue',
                 'core/home/home.component.ts',
+                'core/error/error.vue',
+                'core/error/error.component.ts',
                 'core/jhi-footer/jhi-footer.vue',
                 'core/jhi-footer/jhi-footer.component.ts',
                 'core/jhi-navbar/jhi-navbar.vue',
@@ -371,6 +373,7 @@ function writeFiles() {
     if (!this.enableTranslation) {
         utils.replaceTranslation(this, ['app/app.vue',
             'app/core/home/home.vue',
+            'app/core/error/error.vue',
             'app/core/jhi-footer/jhi-footer.vue',
             'app/core/jhi-navbar/jhi-navbar.vue',
             'app/core/ribbon/ribbon.vue',

--- a/generators/client/templates/vue/src/main/webapp/app/core/error/error.component.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/core/error/error.component.ts.ejs
@@ -1,0 +1,33 @@
+import Component from 'vue-class-component';
+import { Vue } from 'vue-property-decorator';
+
+@Component
+export default class Error extends Vue {
+
+  errorMessage: string = null;
+  error403: boolean = false;
+
+  beforeRouteEnter(to, from, next) {
+    next(vm => {
+      let errorMessage = null;
+      let error403 = false;
+
+      if (to.meta.errorMessage) {
+        errorMessage = to.meta.errorMessage;
+      }
+
+      if (to.meta.error403) {
+        error403 = to.meta.error403;
+      }
+
+       vm.init(errorMessage, error403);
+     });
+  }
+
+  public init(errorMessage: string = null, error403: boolean = false) {
+
+    this.errorMessage = errorMessage;
+    this.error403 = error403;
+  }
+
+}

--- a/generators/client/templates/vue/src/main/webapp/app/core/error/error.vue.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/core/error/error.vue.ejs
@@ -1,0 +1,20 @@
+<template>
+<div>
+  <div class="row">
+  <div class="col-md-3">
+    <span class="hipster img-fluid rounded"></span>
+  </div>
+  <div class="col-md-9">
+    <h1 v-text="$t('error.title')">Error Page!</h1>
+
+    <div v-if="errorMessage">
+      <div class="alert alert-danger">{{errorMessage}}</div>
+    </div>
+      <div v-if="error403" class="alert alert-danger" v-text="$t('error.http.403')">You are not authorized to access this page.</div>
+    </div>
+  </div>
+</div>
+</template>
+
+<script lang="ts" src="./error.component.ts">
+</script>

--- a/generators/client/templates/vue/src/main/webapp/app/core/home/home.vue.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/core/home/home.vue.ejs
@@ -43,32 +43,3 @@
 
 <script lang="ts" src="./home.component.ts">
 </script>
-
-<!-- Add "scoped" attribute to limit CSS to this component only -->
-<style scoped>
-    /* ==========================================================================
-Main page styles
-========================================================================== */
-
-    .hipster {
-        display: inline-block;
-        width: 347px;
-        height: 497px;
-        background: url("../../../content/images/<%=hipster%>.svg") no-repeat center top;
-        background-size: contain;
-    }
-
-    /* wait autoprefixer update to allow simple generation of high pixel density media query */
-    @media only screen and (-webkit-min-device-pixel-ratio: 2),
-    only screen and (min--moz-device-pixel-ratio: 2),
-    only screen and (-o-min-device-pixel-ratio: 2/1),
-    only screen and (min-device-pixel-ratio: 2),
-    only screen and (min-resolution: 192dpi),
-    only screen and (min-resolution: 2dppx) {
-        .hipster {
-            background: url("../../../content/images/<%=hipster%>.svg") no-repeat center top;
-            background-size: contain;
-        }
-    }
-
-</style>

--- a/generators/client/templates/vue/src/main/webapp/app/router/index.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/router/index.ts.ejs
@@ -7,6 +7,7 @@ Component.registerHooks([
 ])
 import Router from 'vue-router';
 const Home = () => import('../core/home/home.vue');
+const Error = () => import('../core/error/error.vue');
 const Register = () => import('../account/register/register.vue');
 const Activate = () => import('../account/activate/activate.vue');
 const ResetPassword = () => import('../account/reset-password/reset-password.vue');
@@ -42,6 +43,12 @@ export default new Router({
       component: Home
     },
     {
+      path: '/forbidden',
+      name: 'Forbidden',
+      component: Error,
+      meta: { error403: true }
+    },
+    {
       path: '/register',
       name: 'Register',
       component: Register
@@ -59,81 +66,96 @@ export default new Router({
     {
       path: '/account/password',
       name: 'ChangePassword',
-      component: ChangePassword
+      component: ChangePassword,
+      meta: { authorities: ['ROLE_USER'] }
     }
     <%_ if (authenticationType === 'session') { _%>,
     {
       path: '/account/sessions',
       name: 'Sessions',
-      component: Sessions
+      component: Sessions,
+      meta: { authorities: ['ROLE_USER'] }
     }<%_ } _%>,
     {
       path: '/account/settings',
       name: 'Settings',
-      component: Settings
+      component: Settings,
+      meta: { authorities: ['ROLE_USER'] }
     },
     {
       path: '/admin/user-management',
       name: '<%= jhiPrefixCapitalized %>User',
-      component: <%= jhiPrefixCapitalized %>UserManagementComponent
+      component: <%= jhiPrefixCapitalized %>UserManagementComponent,
+      meta: { authorities: ['ROLE_ADMIN'] }
     },
     {
       path: '/admin/user-management/new',
       name: '<%= jhiPrefixCapitalized %>UserCreate',
-      component: <%= jhiPrefixCapitalized %>UserManagementEditComponent
+      component: <%= jhiPrefixCapitalized %>UserManagementEditComponent,
+      meta: { authorities: ['ROLE_ADMIN'] }
     },
     {
       path: '/admin/user-management/:userId/edit',
       name: '<%= jhiPrefixCapitalized %>UserEdit',
-      component: <%= jhiPrefixCapitalized %>UserManagementEditComponent
+      component: <%= jhiPrefixCapitalized %>UserManagementEditComponent,
+      meta: { authorities: ['ROLE_ADMIN'] }
     },
     {
       path: '/admin/user-management/:userId/view',
       name: '<%= jhiPrefixCapitalized %>UserView',
-      component: <%= jhiPrefixCapitalized %>UserManagementViewComponent
+      component: <%= jhiPrefixCapitalized %>UserManagementViewComponent,
+      meta: { authorities: ['ROLE_ADMIN'] }
     },
     {
       path: '/admin/docs',
       name: '<%= jhiPrefixCapitalized %>DocsComponent',
-      component: <%= jhiPrefixCapitalized %>DocsComponent
+      component: <%= jhiPrefixCapitalized %>DocsComponent,
+      meta: { authorities: ['ROLE_ADMIN'] }
     },
     {
       path: '/admin/audits',
       name: '<%= jhiPrefixCapitalized %>AuditsComponent',
-      component: <%= jhiPrefixCapitalized %>AuditsComponent
+      component: <%= jhiPrefixCapitalized %>AuditsComponent,
+      meta: { authorities: ['ROLE_ADMIN'] }
     },
     {
       path: '/admin/<%= jhiPrefixDashed %>-health',
       name: '<%= jhiPrefixCapitalized %>HealthComponent',
-      component: <%= jhiPrefixCapitalized %>HealthComponent
+      component: <%= jhiPrefixCapitalized %>HealthComponent,
+      meta: { authorities: ['ROLE_ADMIN'] }
     },
     {
       path: '/admin/logs',
       name: '<%= jhiPrefixCapitalized %>LogsComponent',
-      component: <%= jhiPrefixCapitalized %>LogsComponent
+      component: <%= jhiPrefixCapitalized %>LogsComponent,
+      meta: { authorities: ['ROLE_ADMIN'] }
     },
     {
       path: '/admin/<%= jhiPrefixDashed %>-metrics',
       name: '<%= jhiPrefixCapitalized %>MetricsComponent',
-      component: <%= jhiPrefixCapitalized %>MetricsComponent
+      component: <%= jhiPrefixCapitalized %>MetricsComponent,
+      meta: { authorities: ['ROLE_ADMIN'] }
     },
     {
       path: '/admin/<%= jhiPrefixDashed %>-configuration',
       name: '<%= jhiPrefixCapitalized %>ConfigurationComponent',
-      component: <%= jhiPrefixCapitalized %>ConfigurationComponent
+      component: <%= jhiPrefixCapitalized %>ConfigurationComponent,
+      meta: { authorities: ['ROLE_ADMIN'] }
     }
     <%_ if (applicationType === 'gateway' && serviceDiscoveryType) { _%>,
     {
       path: '/admin/gateway',
       name: '<%= jhiPrefixCapitalized %>GatewayComponent',
-      component: <%= jhiPrefixCapitalized %>GatewayComponent
+      component: <%= jhiPrefixCapitalized %>GatewayComponent,
+      meta: { authorities: ['ROLE_ADMIN'] }
     }
     <%_ } _%>
     <%_ if (websocket === 'spring-websocket') { _%>,
     {
       path: '/admin/<%= jhiPrefixDashed %>-tracker',
       name: '<%= jhiPrefixCapitalized %>TrackerComponent',
-      component: <%= jhiPrefixCapitalized %>TrackerComponent
+      component: <%= jhiPrefixCapitalized %>TrackerComponent,
+      meta: { authorities: ['ROLE_ADMIN'] }
     }
     <%_ } _%>
     // jhipster-needle-add-entity-to-router - JHipster will add entities to the router here

--- a/generators/client/templates/vue/src/main/webapp/content/scss/global.scss.ejs
+++ b/generators/client/templates/vue/src/main/webapp/content/scss/global.scss.ejs
@@ -62,6 +62,31 @@ Browser Upgrade Prompt
 }
 
 /* ==========================================================================
+Main page styles
+========================================================================== */
+
+.hipster {
+    display: inline-block;
+    width: 347px;
+    height: 497px;
+    background: url("../images/<%=hipster%>.svg") no-repeat center top;
+    background-size: contain;
+}
+
+/* wait autoprefixer update to allow simple generation of high pixel density media query */
+@media only screen and (-webkit-min-device-pixel-ratio: 2),
+only screen and (min--moz-device-pixel-ratio: 2),
+only screen and (-o-min-device-pixel-ratio: 2/1),
+only screen and (min-device-pixel-ratio: 2),
+only screen and (min-resolution: 192dpi),
+only screen and (min-resolution: 2dppx) {
+    .hipster {
+        background: url("../images/<%=hipster%>.svg") no-repeat center top;
+        background-size: contain;
+    }
+}
+
+/* ==========================================================================
 Generic styles
 ========================================================================== */
 

--- a/test/client.spec.js
+++ b/test/client.spec.js
@@ -121,6 +121,8 @@ const expectedFiles = {
 
         `${CLIENT_MAIN_SRC_DIR}app/core/home/home.component.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/core/home/home.vue`,
+        `${CLIENT_MAIN_SRC_DIR}app/core/error/error.component.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/core/error/error.vue`,
         `${CLIENT_MAIN_SRC_DIR}app/core/jhi-footer/jhi-footer.component.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/core/jhi-footer/jhi-footer.vue`,
         `${CLIENT_MAIN_SRC_DIR}app/core/jhi-navbar/jhi-navbar.component.ts`,


### PR DESCRIPTION
in preparation for #185 this PR adds a `/forbidden` route and a general error component (very similar to what we have in angular: https://github.com/jhipster/generator-jhipster/tree/master/generators/client/templates/angular/src/main/webapp/app/layouts/error

The added meta data at the routes is currently not evaluated, but it will be done (again similar to  https://github.com/jhipster/generator-jhipster/blob/master/generators/client/templates/angular/src/main/webapp/app/core/auth/user-route-access-service.ts.ejs) such that the user is forwarded to `/forbidden` and prompted to login in case the user not logged in.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-vuejs/pull_requests) are green
-   [ ] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-vuejs/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
