### PR TITLE
Add blueprint generator dependency to package.json

### DIFF
--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -3,6 +3,7 @@ const chalk = require('chalk');
 const ClientGenerator = require('generator-jhipster/generators/client');
 const prompts = require('./prompts');
 const writeFiles = require('./files').writeFiles;
+const blueprintPackagejs = require('../../package.json');
 
 module.exports = class extends ClientGenerator {
     constructor(args, opts) {
@@ -19,6 +20,7 @@ module.exports = class extends ClientGenerator {
         }
 
         this.configOptions = jhContext.configOptions || {};
+        this.blueprintjs = blueprintPackagejs;
         // This sets up options for this sub generator and is being reused from JHipster
         jhContext.setupClientOptions(this, jhContext);
     }
@@ -91,13 +93,11 @@ module.exports = class extends ClientGenerator {
 
     get writing() {
         // The writing phase is being overriden so that we can write our own templates as well.
-        // If the templates doesnt need to be overrriden then just return `super._writing()` here
-        const customPhaseSteps = {
+        return {
             writeAdditionalFile() {
                 writeFiles.call(this);
             }
         };
-        return customPhaseSteps;
     }
 
     get install() {

--- a/generators/client/templates/vue/package.json.ejs
+++ b/generators/client/templates/vue/package.json.ejs
@@ -81,6 +81,7 @@ limitations under the License.
     "css-loader": "1.0.1",
     "file-loader": "1.1.11",
     "friendly-errors-webpack-plugin": "1.7.0",
+    "generator-jhipster-vuejs": "<%= blueprintjs.version %>",
     "html-webpack-plugin": "3.2.0",
     <%_ if (!skipCommitHook) { _%>
     "husky": "1.2.0",

--- a/test/generator.spec.js
+++ b/test/generator.spec.js
@@ -2,6 +2,7 @@ const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');
 const constants = require('generator-jhipster/generators/generator-constants');
+const blueprintPackagejs = require('../package.json');
 
 const CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
 const CLIENT_TEST_SRC_DIR = constants.CLIENT_TEST_SRC_DIR;
@@ -249,6 +250,7 @@ describe('Vue.js JHipster blueprint', () => {
             assert.file(expectedFiles.webpack);
         });
         it('contains the specific change added by the blueprint', () => {
+            assert.fileContent('package.json', `"generator-jhipster-vuejs": "${blueprintPackagejs.version}"`);
             assert.fileContent('package.json', '"vue"');
             assert.fileContent('package.json', '"vuex"');
             assert.fileContent('package.json', '"vuelidate"');
@@ -311,6 +313,7 @@ describe('Vue.js JHipster blueprint', () => {
             assert.file(expectedFiles.webpack);
         });
         it('contains the specific change added by the blueprint', () => {
+            assert.fileContent('package.json', `"generator-jhipster-vuejs": "${blueprintPackagejs.version}"`);
             assert.fileContent('package.json', '"vue"');
             assert.fileContent('package.json', '"vuex"');
             assert.fileContent('package.json', '"vuelidate"');
@@ -372,6 +375,7 @@ describe('Vue.js JHipster blueprint', () => {
             assert.file(expectedFiles.webpack);
         });
         it('contains the specific change added by the blueprint', () => {
+            assert.fileContent('package.json', `"generator-jhipster-vuejs": "${blueprintPackagejs.version}"`);
             assert.fileContent('package.json', '"vue"');
             assert.fileContent('package.json', '"vuex"');
             assert.fileContent('package.json', '"vuelidate"');
@@ -436,6 +440,7 @@ describe('Vue.js JHipster blueprint', () => {
             assert.file(expectedFiles.webpack);
         });
         it('contains the specific change added by the blueprint', () => {
+            assert.fileContent('package.json', `"generator-jhipster-vuejs": "${blueprintPackagejs.version}"`);
             assert.fileContent('package.json', '"vue"');
             assert.fileContent('package.json', '"vuex"');
             assert.fileContent('package.json', '"vuelidate"');
@@ -501,6 +506,7 @@ describe('Vue.js JHipster blueprint', () => {
             assert.file(expectedFiles.webpack);
         });
         it('contains the specific change added by the blueprint', () => {
+            assert.fileContent('package.json', `"generator-jhipster-vuejs": "${blueprintPackagejs.version}"`);
             assert.fileContent('package.json', '"vue"');
             assert.fileContent('package.json', '"vuex"');
             assert.fileContent('package.json', '"vuelidate"');


### PR DESCRIPTION
Closes #76.

There may be a better way to retrieve blueprint generator version, feel free to comment if so.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-vuejs/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-vuejs/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
