### PR TITLE
Clean npm test logs output for pagination

### DIFF
--- a/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity-management.component.spec.ts.ejs
+++ b/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity-management.component.spec.ts.ejs
@@ -56,7 +56,7 @@ describe('Component Tests', () => {
 
     beforeEach(() => {
       mockedAxios.get.mockReset();
-      mockedAxios.get.mockReturnValue(Promise.resolve({}));
+      mockedAxios.get.mockReturnValue(Promise.resolve({ headers: {}}));
 
       wrapper = shallowMount<<%= entityAngularName %>Class>(<%= entityAngularName %>Component, {
         store,
@@ -79,7 +79,7 @@ describe('Component Tests', () => {
 
     it('Should call load all on init', async () => {
       // GIVEN
-      mockedAxios.get.mockReturnValue(Promise.resolve({data: [{id: <%- tsKeyId %>}]}));
+      mockedAxios.get.mockReturnValue(Promise.resolve({headers: {}, data: [{id: <%- tsKeyId %>}]}));
 
       // WHEN
       comp.retrieveAll<%= entityAngularName %>s();
@@ -93,7 +93,7 @@ describe('Component Tests', () => {
 
     it('should load a page', async () => {
       // GIVEN
-      mockedAxios.get.mockReturnValue(Promise.resolve({data: [{id: <%- tsKeyId %>}]}));
+      mockedAxios.get.mockReturnValue(Promise.resolve({headers: {}, data: [{id: <%- tsKeyId %>}]}));
 
       // WHEN
       comp.loadPage(1);
@@ -121,7 +121,7 @@ describe('Component Tests', () => {
     it('should re-initialize the page', async () => {
       // GIVEN
       mockedAxios.get.mockReset();
-      mockedAxios.get.mockReturnValue(Promise.resolve({data: [{id: <%- tsKeyId %>}]}));
+      mockedAxios.get.mockReturnValue(Promise.resolve({headers: {}, data: [{id: <%- tsKeyId %>}]}));
 
       // WHEN
       comp.loadPage(2);


### PR DESCRIPTION
Related to https://github.com/jhipster/jhipster-vuejs/issues/220

It should remove this warning:
```
(node:9845) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'x-total-count' of undefined
```

_____


-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-vuejs/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-vuejs/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
