### PR TITLE
Add created method to init many-to-many fields

### DIFF
--- a/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-update.component.ts.ejs
+++ b/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-update.component.ts.ejs
@@ -19,11 +19,15 @@ import { DATE_TIME_LONG_FORMAT, INSTANT_FORMAT, ZONED_DATE_TIME_FORMAT } from '@
 
 <%_
     const importEntitiesSeen = [entityAngularName];
+    let hasManyToMany = false;
     for (idx in relationships) {
     const otherEntityAngularName = relationships[idx].otherEntityAngularName;
     const otherEntityFileName = relationships[idx].otherEntityFileName;
     const otherEntityFolderName = relationships[idx].otherEntityFileName;
     const otherEntityModelName = relationships[idx].otherEntityModelName;
+    if (relationships[idx].relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) {
+      hasManyToMany = true;
+    }
 _%>
   <% if (otherEntityAngularName === 'User' && authenticationType !== "oauth2") { %>
 import UserService from '@/admin/user-management/user-management.service';
@@ -95,6 +99,18 @@ export default class <%= entityAngularName %>Update extends <% if (fieldsContain
       <%_ } _%>
     });
   }
+
+  <%_ if (hasManyToMany) { _%>
+  created(): void {
+    <%_
+      for (idx in relationships) {
+      const otherEntityNamePlural = relationships[idx].otherEntityNamePlural;
+      if (relationships[idx].relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) {
+    _%>
+    this.<%= entityInstance %>.<%= otherEntityNamePlural %> = [];
+    <%_ } } _%>
+  }
+  <%_ } _%>
 
   public save() : void {
     this.isSaving = true;
@@ -202,14 +218,10 @@ export default class <%= entityAngularName %>Update extends <% if (fieldsContain
   <%_ } _%>
   public initRelationships() : void {
     <%_
-        let hasManyToMany = false;
         for (idx in relationships) {
         const otherEntityName = relationships[idx].otherEntityName;
         const otherEntityNamePlural = relationships[idx].otherEntityNamePlural;
         const otherEntityAngularName = relationships[idx].otherEntityAngularName;
-        if (relationships[idx].relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) {
-            hasManyToMany = true;
-        }
         if (!(otherEntityAngularName === 'User' && authenticationType === "oauth2")) {
     _%>
     this.<%= otherEntityName %>Service().retrieve().then((res) => {


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-vuejs/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-vuejs/blob/master/CONTRIBUTING.md) are followed

Avoid having an error in the console by initializing `many-to-many` fields with an empty array in the `created` method.

![image](https://user-images.githubusercontent.com/2212267/52222056-a1f2c180-2870-11e9-86b1-958cae6b8405.png)

I first wanted to change the model's constructor and have an empty array as default value. But that requires changing the method `generateEntityClientFields` from the main generator.

Let me know if the `created` method is the best way.