### PR TITLE
Entities submenu keeps repeating when force-reimporting the JDL

### DIFF
--- a/generators/utils.js
+++ b/generators/utils.js
@@ -120,13 +120,13 @@ function addEntityToMenu(generator, entityName, translationKey, className) {
         {
             file: `${CLIENT_MAIN_SRC_DIR}/app/core/jhi-navbar/jhi-navbar.vue`,
             needle: 'jhipster-needle-add-entity-to-menu',
-            splicable: [
+            splicable: [generator.stripMargin(
                 // prettier-ignore
                 `<b-dropdown-item to="/entity/${entityName}" v-on:click="collapseNavbar()">
                     <font-awesome-icon icon="asterisk" />
                     <span ${menuI18nTitle}>${className}</span>
               </b-dropdown-item>`
-            ]
+            )]
         },
         generator
     );


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-vuejs/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-vuejs/blob/master/CONTRIBUTING.md) are followed

When reimporting the entire JDL over and over again with `jhipster import-jdl my-jdl.jh --force` the "Entities" submenu would regenerate the list of Entities and they would start showing up multiple times.

It would look something like then (when force-importing twice):

![grafik](https://user-images.githubusercontent.com/903321/52312583-5db80c00-29ab-11e9-84a4-f73475e22617.png)