### PR TITLE
Switch to master branch for jhipster lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ env:
     - JHI_ENTITY=sql
     # if JHI_LIB_BRANCH value is release, use the release from Maven
     - JHI_LIB_REPO=https://github.com/jhipster/jhipster.git
-    - JHI_LIB_BRANCH=release
+    - JHI_LIB_BRANCH=master
     # if JHI_GEN_BRANCH value is release, use the release from NPM
     - JHI_GEN_REPO=https://github.com/jhipster/generator-jhipster.git
     - JHI_GEN_BRANCH=master


### PR DESCRIPTION
Waiting the release of jhipster lib, we need to switch to master branch.
The build will fail because of https://github.com/jhipster/jhipster-vuejs/issues/294

_____


-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-vuejs/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-vuejs/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
