### PR TITLE
Update jhipster core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -863,11 +863,6 @@
         "array-find-index": "^1.0.1"
       }
     },
-    "cycle": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
-    },
     "dargs": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-6.0.0.tgz",
@@ -1715,11 +1710,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "eyes": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
     "fast-deep-equal": {
       "version": "1.1.0",
@@ -2729,36 +2719,30 @@
       }
     },
     "jhipster-core": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jhipster-core/-/jhipster-core-3.0.2.tgz",
-      "integrity": "sha512-b5wZgA/E3S547mDKg6g4bzGYC+fLBr4LUBcpcMtqZ4UubHrIFIOT9eqw/rF0yRzU/w8UeVgp/Sqi77PVKg9jag==",
+      "version": "3.6.8",
+      "resolved": "https://registry.npmjs.org/jhipster-core/-/jhipster-core-3.6.8.tgz",
+      "integrity": "sha512-XRrbWxPdmfVxDXMtVdetyupnHzwbJBaxs+gRA4mlheZnwu/2wDqnH/h9iJBCtxlIfVV/8HiZMNC0orb7h6E2Zw==",
       "requires": {
-        "lodash": "4.17.10",
-        "winston": "2.4.2"
+        "chevrotain": "4.1.1",
+        "fs-extra": "7.0.1",
+        "lodash": "4.17.11",
+        "winston": "3.1.0"
       },
       "dependencies": {
-        "async": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
-        },
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-        },
-        "winston": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.2.tgz",
-          "integrity": "sha512-4S/Ad4ZfSNl8OccCLxnJmNISWcm2joa6Q0YGDxlxMzH0fgSwWsjMt+SmlNwCqdpaPg3ev1HKkMBsIiXeSUwpbA==",
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
           "requires": {
-            "async": "~1.0.0",
-            "colors": "1.0.x",
-            "cycle": "1.0.x",
-            "eyes": "0.1.x",
-            "isstream": "0.1.x",
-            "stack-trace": "0.0.x"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "glob": "7.1.2",
     "gulp-filter": "5.1.0",
     "insight": "0.10.1",
-    "jhipster-core": "3.0.2",
+    "jhipster-core": "3.6.8",
     "js-yaml": "3.12.0",
     "lodash": "4.17.10",
     "meow": "5.0.0",


### PR DESCRIPTION
This updates to jhipster-core 3.6.8. JHipster 5.8.1 is currently at 3.6.9 but this has issues and I believe 3.6.8 is the last one without issues.

Will also need to update to 3.6.11 which resolves all regressions introduced in 3.6.9 and 3.6.10 as soon as @MathieuAA also update the parent generator. See also comments at https://github.com/jhipster/jhipster-core/pull/305

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-vuejs/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-vuejs/blob/master/CONTRIBUTING.md) are followed
