### PR TITLE
fix webpack proxy when client/server are separated

### DIFF
--- a/generators/client/templates/vue/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/vue/webpack/webpack.dev.js.ejs
@@ -35,7 +35,15 @@ module.exports = merge(baseWebpackConfig, {
     proxy: [
       {
         context: [
-          '/'
+          '/api',
+          '/services',
+          '/management',
+          '/swagger-resources',
+          '/v2/api-docs',
+          '/h2-console',<% if (authenticationType === 'oauth2') { %>
+          '/oauth2',
+          '/login',<% } %>
+          '/auth'
         ],
         target: 'http://127.0.0.1:8080',
         secure: false,
@@ -44,7 +52,8 @@ module.exports = merge(baseWebpackConfig, {
     ],
     watchOptions: {
       ignored: /node_modules/
-    }
+    },
+    historyApiFallback: true
   },
   plugins: [
     new webpack.DefinePlugin({


### PR DESCRIPTION
When using separate client/server, ClientForwardController and index.html do not exist on the backend.  Refreshing http://localhost:9000/account/settings when using the webpack-dev-server (port 9000) gives a server-side 404.  

To fix that we need to add the paths back to the webpack proxy so it will know to load the frontend for non-server routes (currently all requests go to backend based on `/`).

Then webpack gives a 404 of its own, which is fixed by adding [`historyApiFallback`](https://webpack.js.org/configuration/dev-server/#devserverhistoryapifallback)

Very simple to reproduce with the JDL in the linked issue, just try going directly to http://localhost:9000/account/settings after running `npm start`

related to jhipster/generator-jhipster#9839, https://github.com/jhipster/jhipster-vuejs/issues/376, https://github.com/jhipster/jhipster-vuejs/issues/371

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-vuejs/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-vuejs/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
