### PR TITLE
Fix ci: add a step to reinstall generator-jhipster librairies

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -117,6 +117,11 @@ jobs:
             displayName: 'GENERATION: project'
           - bash: $(JHI_SCRIPTS)/13-replace-version-generated-project.sh
             displayName: 'GENERATION: replace version in generated project'
+          - script: |
+              set -e
+              cd "$HOME"/generator-jhipster
+              npm ci
+            displayName: 'Reinstall Generator JHipster librairies'
           - bash: $(JHI_SCRIPTS)/14-jhipster-info.sh
             displayName: 'GENERATION: jhipster info'
 


### PR DESCRIPTION
Fix #469 

I think it will work, but I think also there is a better way to do this.

ping @pascalgrimaud 

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-vuejs/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-vuejs/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
