### PR TITLE
fix links in router-link to navigate through entities

### DIFF
--- a/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-details.vue.ejs
+++ b/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-details.vue.ejs
@@ -68,16 +68,16 @@
                             <%_ } else { _%>
                                 <%_ if (relationshipType === 'many-to-many') { _%>
                         <span v-for="(<%= relationshipFieldName %>, i) in <%= entityInstance %>.<%= relationshipFieldNamePlural %>" :key="<%= relationshipFieldName %>.id">{{i > 0 ? ', ' : ''}}
-                            <router-link :to="{name: '<%= otherEntityAngularName %>View', params: {<%= relationshipFieldName %>Id: <%= relationshipFieldName %>.id}}">{{<%= relationshipFieldName + "." + otherEntityField %>}}</router-link>
+                            <router-link :to="{name: '<%= otherEntityAngularName %>View', params: {<%= otherEntityName %>Id: <%= relationshipFieldName %>.id}}">{{<%= relationshipFieldName + "." + otherEntityField %>}}</router-link>
                         </span>
                                 <%_ } else { _%>
                                     <%_ if (dto === 'no') { _%>
                         <div v-if="<%= entityInstance + '.' + relationshipFieldName %>">
-                            <router-link :to="{name: '<%= otherEntityAngularName %>View', params: {<%= relationshipFieldName %>Id: <%= entityInstance + "." + relationshipFieldName %>.id}}">{{<%= entityInstance + "." + relationshipFieldName + "." + otherEntityField %>}}</router-link>
+                            <router-link :to="{name: '<%= otherEntityAngularName %>View', params: {<%= otherEntityName %>Id: <%= entityInstance + "." + relationshipFieldName %>.id}}">{{<%= entityInstance + "." + relationshipFieldName + "." + otherEntityField %>}}</router-link>
                         </div>
                                     <%_ } else { _%>
                         <div v-if="<%= entityInstance + '.' + relationshipFieldName + "Id" %>">
-                            <router-link :to="{name: '<%= otherEntityAngularName %>View', params: {<%= relationshipFieldName %>Id: <%= entityInstance + "." + relationshipFieldName + "Id" %>}}">{{<%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %>}}</router-link>
+                            <router-link :to="{name: '<%= otherEntityAngularName %>View', params: {<%= otherEntityName %>Id: <%= entityInstance + "." + relationshipFieldName + "Id" %>}}">{{<%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %>}}</router-link>
                         </div>
                                     <%_ } _%>
                                 <%_ } _%>

--- a/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity.vue.ejs
+++ b/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity.vue.ejs
@@ -122,16 +122,16 @@
                             <%_ } else { _%>
                                 <%_ if (relationshipType === 'many-to-many') { _%>
                         <span v-for="(<%= relationshipFieldName %>, i) in <%= entityInstance %>.<%= relationshipFieldNamePlural %>" :key="<%= relationshipFieldName %>.id">{{i > 0 ? ', ' : ''}}
-                            <router-link class="form-control-static" :to="{name: '<%= otherEntityAngularName %>View', params: {<%= relationshipFieldName %>Id: <%= relationshipFieldName %>.id}}">{{<%= relationshipFieldName + "." + otherEntityField %>}}</router-link>
+                            <router-link class="form-control-static" :to="{name: '<%= otherEntityAngularName %>View', params: {<%= otherEntityName %>Id: <%= relationshipFieldName %>.id}}">{{<%= relationshipFieldName + "." + otherEntityField %>}}</router-link>
                         </span>
                                 <%_ } else { _%>
                                     <%_ if (dto === 'no') { _%>
                         <div v-if="<%= entityInstance + "." + relationshipFieldName %>">
-                            <router-link :to="{name: '<%= otherEntityAngularName %>View', params: {<%= relationshipFieldName %>Id: <%= entityInstance + "." + relationshipFieldName %>.id}}">{{<%= entityInstance + "." + relationshipFieldName + "." + otherEntityField %>}}</router-link>
+                            <router-link :to="{name: '<%= otherEntityAngularName %>View', params: {<%= otherEntityName %>Id: <%= entityInstance + "." + relationshipFieldName %>.id}}">{{<%= entityInstance + "." + relationshipFieldName + "." + otherEntityField %>}}</router-link>
                         </div>
                                     <%_ } else { _%>
                         <div v-if="<%= entityInstance + "." + relationshipFieldName + "Id" %>">
-                            <router-link :to="{name: '<%= otherEntityAngularName %>View', params: {<%= relationshipFieldName %>Id: <%= entityInstance + "." + relationshipFieldName + "Id" %>}}">{{<%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %>}}</router-link>
+                            <router-link :to="{name: '<%= otherEntityAngularName %>View', params: {<%= otherEntityName %>Id: <%= entityInstance + "." + relationshipFieldName + "Id" %>}}">{{<%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %>}}</router-link>
                         </div>
                                     <%_ } _%>
                                 <%_ } _%>


### PR DESCRIPTION
1) fix link to be able to click on **Trace** (manytoone relation)
![image](https://user-images.githubusercontent.com/766263/67150879-c509b800-f2bd-11e9-8299-9647f20f5398.png)

2) fix links to be able to click on **mobile Fish**, **Home Loan Account Table Computer** and **Trace** (manytomany and manytoone relations)
![image](https://user-images.githubusercontent.com/766263/67150910-12862500-f2be-11e9-86b4-f251ea897d7a.png)

This bug occurs only when the field name is different from the entity name. (here "tasks" and "toto")
