### PR TITLE
use https everywhere so no-http check works fine

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > JHipster-vuejs, a Vue.js blueprint for JHipster. It will use [Vue.js](https://vuejs.org/) as the frontend library.
 
 <div align="center">
-  <a href="http://www.jhipster.tech/">
+  <a href="https://www.jhipster.tech/">
     <img src="https://github.com/jhipster/jhipster-artwork/blob/master/logos/JHipster%20RGB-small100x25px.png?raw=true">
   </a>
   <a href="https://vuejs.org/">
@@ -14,11 +14,11 @@
 
 # Introduction
 
-This is a [JHipster](http://www.jhipster.tech/) blueprint.
+This is a [JHipster](https://www.jhipster.tech/) blueprint.
 
 # Prerequisites
 
-As this is a [JHipster](http://www.jhipster.tech/) blueprint, we expect you have JHipster and its related tools already installed:
+As this is a [JHipster](https://www.jhipster.tech/) blueprint, we expect you have JHipster and its related tools already installed:
 
 - [Installing JHipster](https://www.jhipster.tech/installation/)
 

--- a/generators/common/templates/README.md.ejs
+++ b/generators/common/templates/README.md.ejs
@@ -317,21 +317,21 @@ To configure CI for your project, run the ci-cd sub-generator (`jhipster ci-cd`)
 [Running tests page]: <%= DOCUMENTATION_ARCHIVE_URL %>/running-tests/
 [Code quality page]: <%= DOCUMENTATION_ARCHIVE_URL %>/code-quality/
 [Setting up Continuous Integration]: <%= DOCUMENTATION_ARCHIVE_URL %>/setting-up-ci/
-<% if (testFrameworks.includes("gatling")) { %>[Gatling]: http://gatling.io/<% } %>
+<% if (testFrameworks.includes("gatling")) { %>[Gatling]: https://gatling.io/<% } %>
 <%_ if (!skipClient) {_%>
 [Node.js]: https://nodejs.org/
 [Yarn]: https://yarnpkg.org/
 [Webpack]: https://webpack.github.io/
 [Vue CLI]: https://cli.vuejs.org/
-[BrowserSync]: http://www.browsersync.io/
+[BrowserSync]: https://www.browsersync.io/
 [Jest]: https://facebook.github.io/jest/
-[Jasmine]: http://jasmine.github.io/2.0/introduction.html
-[Protractor]: http://www.protractortest.org/
-[Leaflet]: http://leafletjs.com/
-[DefinitelyTyped]: http://definitelytyped.org/
+[Jasmine]: https://jasmine.github.io/2.0/introduction.html
+[Protractor]: https://www.protractortest.org/
+[Leaflet]: https://leafletjs.com/
+[DefinitelyTyped]: https://definitelytyped.org/
 <%_ } _%>
 <%_ if (enableSwaggerCodegen) { _%>
 [OpenAPI-Generator]: https://openapi-generator.tech
-[Swagger-Editor]: http://editor.swagger.io
+[Swagger-Editor]: https://editor.swagger.io
 [Doing API-First development]: <%= DOCUMENTATION_ARCHIVE_URL %>/doing-api-first-development/
 <%_ } _%>


### PR DESCRIPTION
This uses https everywhere such that the no-http checkstyle check works now in ci.  See https://github.com/jhipster/jhipster-vuejs/pull/493
[skip ci]

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Azure tests](https://dev.azure.com/jhipster/jhipster-vuejs/_build) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-vuejs/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
