### PR TITLE
Add authority enum

### DIFF
--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -134,6 +134,7 @@ const vueFiles = {
                 'shared/config/config-bootstrap-vue.ts',
                 'shared/config/store/account-store.ts',
                 'shared/config/store/alert-store.ts',
+                'shared/security/authority.ts',
                 'router/index.ts'
             ]
         }

--- a/generators/client/templates/vue/src/main/webapp/app/admin/user-management/user-management.service.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/admin/user-management/user-management.service.ts.ejs
@@ -1,6 +1,9 @@
 import axios from 'axios';
 import Vue from 'vue';
 import buildPaginationQueryOpts from '@/shared/sort/sorts';
+<%_ if (databaseType !== 'sql' && databaseType !== 'mongodb' || databaseType !== 'couchbase') { _%>
+import {Authority} from '@/shared/security/authority'
+<%_ } _%>
 
 export default class UserManagementService {
 
@@ -28,7 +31,7 @@ export default class UserManagementService {
     <%_ if (databaseType === 'sql' || databaseType === 'mongodb' || databaseType === 'couchbase') { _%>
     return axios.get('<%- apiUaaPath %>api/users/authorities');
     <%_ } else { _%>
-    return Promise.resolve(['ROLE_USER', 'ROLE_ADMIN']);
+    return Promise.resolve([Authority.USER, Authority.ADMIN]);
     <%_ } _%>
   }
 }

--- a/generators/client/templates/vue/src/main/webapp/app/router/index.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/router/index.ts.ejs
@@ -6,6 +6,7 @@ Component.registerHooks([
   'beforeRouteUpdate' // for vue-router 2.2+
 ])
 import Router from 'vue-router';
+import {Authority} from '@/shared/security/authority';
 const Home = () => import('../core/home/home.vue');
 const Error = () => import('../core/error/error.vue');
 <%_ if (!skipUserManagement) { _%>
@@ -86,89 +87,89 @@ export default new Router({
       path: '/account/password',
       name: 'ChangePassword',
       component: ChangePassword,
-      meta: { authorities: ['ROLE_USER'] }
+      meta: { authorities: [Authority.USER] }
     },
     <%_ if (authenticationType === 'session') { _%>
     {
       path: '/account/sessions',
       name: 'Sessions',
       component: Sessions,
-      meta: { authorities: ['ROLE_USER'] }
+      meta: { authorities: [Authority.USER] }
     },
     <%_ } _%>
     {
       path: '/account/settings',
       name: 'Settings',
       component: Settings,
-      meta: { authorities: ['ROLE_USER'] }
+      meta: { authorities: [Authority.USER] }
     },
     {
       path: '/admin/user-management',
       name: '<%= jhiPrefixCapitalized %>User',
       component: <%= jhiPrefixCapitalized %>UserManagementComponent,
-      meta: { authorities: ['ROLE_ADMIN'] }
+      meta: { authorities: [Authority.ADMIN] }
     },
     {
       path: '/admin/user-management/new',
       name: '<%= jhiPrefixCapitalized %>UserCreate',
       component: <%= jhiPrefixCapitalized %>UserManagementEditComponent,
-      meta: { authorities: ['ROLE_ADMIN'] }
+      meta: { authorities: [Authority.ADMIN] }
     },
     {
       path: '/admin/user-management/:userId/edit',
       name: '<%= jhiPrefixCapitalized %>UserEdit',
       component: <%= jhiPrefixCapitalized %>UserManagementEditComponent,
-      meta: { authorities: ['ROLE_ADMIN'] }
+      meta: { authorities: [Authority.ADMIN] }
     },
     {
       path: '/admin/user-management/:userId/view',
       name: '<%= jhiPrefixCapitalized %>UserView',
       component: <%= jhiPrefixCapitalized %>UserManagementViewComponent,
-      meta: { authorities: ['ROLE_ADMIN'] }
+      meta: { authorities: [Authority.ADMIN] }
     }<% } %>,
     {
       path: '/admin/docs',
       name: '<%= jhiPrefixCapitalized %>DocsComponent',
       component: <%= jhiPrefixCapitalized %>DocsComponent,
-      meta: { authorities: ['ROLE_ADMIN'] }
+      meta: { authorities: [Authority.ADMIN] }
     },
     <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
     {
       path: '/admin/audits',
       name: '<%= jhiPrefixCapitalized %>AuditsComponent',
       component: <%= jhiPrefixCapitalized %>AuditsComponent,
-      meta: { authorities: ['ROLE_ADMIN'] }
+      meta: { authorities: [Authority.ADMIN] }
     },<% } %>
     {
       path: '/admin/<%= jhiPrefixDashed %>-health',
       name: '<%= jhiPrefixCapitalized %>HealthComponent',
       component: <%= jhiPrefixCapitalized %>HealthComponent,
-      meta: { authorities: ['ROLE_ADMIN'] }
+      meta: { authorities: [Authority.ADMIN] }
     },
     {
       path: '/admin/logs',
       name: '<%= jhiPrefixCapitalized %>LogsComponent',
       component: <%= jhiPrefixCapitalized %>LogsComponent,
-      meta: { authorities: ['ROLE_ADMIN'] }
+      meta: { authorities: [Authority.ADMIN] }
     },
     {
       path: '/admin/<%= jhiPrefixDashed %>-metrics',
       name: '<%= jhiPrefixCapitalized %>MetricsComponent',
       component: <%= jhiPrefixCapitalized %>MetricsComponent,
-      meta: { authorities: ['ROLE_ADMIN'] }
+      meta: { authorities: [Authority.ADMIN] }
     },
     {
       path: '/admin/<%= jhiPrefixDashed %>-configuration',
       name: '<%= jhiPrefixCapitalized %>ConfigurationComponent',
       component: <%= jhiPrefixCapitalized %>ConfigurationComponent,
-      meta: { authorities: ['ROLE_ADMIN'] }
+      meta: { authorities: [Authority.ADMIN] }
     }
     <%_ if (applicationType === 'gateway' && serviceDiscoveryType) { _%>,
     {
       path: '/admin/gateway',
       name: '<%= jhiPrefixCapitalized %>GatewayComponent',
       component: <%= jhiPrefixCapitalized %>GatewayComponent,
-      meta: { authorities: ['ROLE_ADMIN'] }
+      meta: { authorities: [Authority.ADMIN] }
     }
     <%_ } _%>
     <%_ if (websocket === 'spring-websocket') { _%>,
@@ -176,7 +177,7 @@ export default new Router({
       path: '/admin/<%= jhiPrefixDashed %>-tracker',
       name: '<%= jhiPrefixCapitalized %>TrackerComponent',
       component: <%= jhiPrefixCapitalized %>TrackerComponent,
-      meta: { authorities: ['ROLE_ADMIN'] }
+      meta: { authorities: [Authority.ADMIN] }
     }
     <%_ } _%>
     // jhipster-needle-add-entity-to-router - JHipster will add entities to the router here

--- a/generators/client/templates/vue/src/main/webapp/app/shared/security/authority.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/shared/security/authority.ts.ejs
@@ -1,0 +1,4 @@
+export enum Authority {
+    ADMIN = 'ROLE_ADMIN',
+    USER = 'ROLE_USER'
+}

--- a/generators/client/templates/vue/src/test/javascript/spec/app/admin/user-management/user-management-view.component.spec.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/spec/app/admin/user-management/user-management-view.component.spec.ts.ejs
@@ -9,6 +9,7 @@ import * as config from '@/shared/config/config';
 import UserManagementView from '@/admin/user-management/user-management-view.vue';
 import UserManagementViewClass from '@/admin/user-management/user-management-view.component';
 import UserManagementService from '@/admin/user-management/user-management.service';
+import {Authority} from '@/shared/security/authority';
 
 const localVue = createLocalVue();
 const mockedAxios: any = axios;
@@ -51,7 +52,7 @@ describe('UserManagementView Component', () => {
         email: 'first@last.com',
         activated: true,
         langKey: 'en',
-        authorities: ['ROLE_USER'],
+        authorities: [Authority.USER],
         createdBy: 'admin',
         createdDate: null,
         lastModifiedBy: null,

--- a/generators/utils.js
+++ b/generators/utils.js
@@ -243,25 +243,25 @@ function addEntityToRouter(generator, entityName, entityFileName, entityAngularN
                         |      path: '/${entityFileName}',
                         |      name: '${entityAngularName}',
                         |      component: ${entityAngularName},
-                        |      meta: { authorities: ['ROLE_USER'] }
+                        |      meta: { authorities: [Authority.USER] }
                         |    },
                         |    {
                         |      path: '/${entityFileName}/new',
                         |      name: '${entityAngularName}Create',
                         |      component: ${entityAngularName}Update,
-                        |      meta: { authorities: ['ROLE_USER'] }
+                        |      meta: { authorities: [Authority.USER] }
                         |    },
                         |    {
                         |      path: '/${entityFileName}/:${entityName}Id/edit',
                         |      name: '${entityAngularName}Edit',
                         |      component: ${entityAngularName}Update,
-                        |      meta: { authorities: ['ROLE_USER'] }
+                        |      meta: { authorities: [Authority.USER] }
                         |    },
                         |    {
                         |      path: '/${entityFileName}/:${entityName}Id/view',
                         |      name: '${entityAngularName}View',
                         |      component: ${entityAngularName}Details,
-                        |      meta: { authorities: ['ROLE_USER'] }
+                        |      meta: { authorities: [Authority.USER] }
                         |    }`
                 )]
             },
@@ -279,13 +279,13 @@ function addEntityToRouter(generator, entityName, entityFileName, entityAngularN
                         |      path: '/${entityFileName}',
                         |      name: '${entityAngularName}',
                         |      component: ${entityAngularName},
-                        |      meta: { authorities: ['ROLE_USER'] }
+                        |      meta: { authorities: [Authority.USER] }
                         |    },
                         |    {
                         |      path: '/${entityFileName}/:${entityName}Id/view',
                         |      name: '${entityAngularName}View',
                         |      component: ${entityAngularName}Details,
-                        |      meta: { authorities: ['ROLE_USER'] }
+                        |      meta: { authorities: [Authority.USER] }
                         |    }`
                 )]
             },
@@ -349,7 +349,7 @@ function addPageToRouter(generator, pageName, pageFolderName) {
                 |      path: '/pages/${pageFolderName}',
                 |      name: '${pageName}',
                 |      component: ${pageName},
-                |      meta: { authorities: ['ROLE_USER'] }
+                |      meta: { authorities: [Authority.USER] }
                 |    }`
             )]
         },


### PR DESCRIPTION
Because, like uncle Bob said: “Duplication may be the root of all evil in software.” 

Add an enum listing authorities in frontend
Use it to describe which authority can access a given route in Vue router.

To be honest, I would have loved to use this enum where the string "ROLE_ADMIN" is used in template, but the only way I found to do it is to bind the enum to the component data and this solution does not satisfy me...

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Azure tests](https://dev.azure.com/jhipster/jhipster-vuejs/_build) are green
-   [ ] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-vuejs/blob/master/CONTRIBUTING.md) are followed