### PR TITLE
Fix vue warn about unknow custom element jhi-sort-indicator

### DIFF
--- a/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity-management.component.spec.ts.ejs
+++ b/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity-management.component.spec.ts.ejs
@@ -39,6 +39,9 @@ const store = config.initVueXStore(localVue);
 localVue.component('font-awesome-icon', {});
 localVue.component('b-alert', {});
 localVue.component('b-badge', {});
+<%_ if (pagination !== 'no') { _%>
+localVue.component('jhi-sort-indicator', {});
+<%_ } _%>
 localVue.directive('b-modal', {});
 localVue.component('b-button', {});
 localVue.component('router-link', {});


### PR DESCRIPTION
It's for removing this warning during `npm test` :

```
 PASS  src/test/javascript/spec/app/entities/test-root/operation/operation.component.spec.ts (216 MB heap size)
  ● Console

    console.error node_modules/vue/dist/vue.runtime.common.dev.js:621
      [Vue warn]: Unknown custom element: <jhi-sort-indicator> - did you register the component correctly? For recursive components, make sure to provide the "name" option.
      
      found in
      
      ---> <Operation>
             <Root>
    console.error node_modules/vue/dist/vue.runtime.common.dev.js:621
```

_____

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/jhipster-vuejs/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-vuejs/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
