### PR TITLE
custom css is loaded also in prod mode

### DIFF
--- a/generators/client/templates/vue/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/vue/webpack/webpack.prod.js.ejs
@@ -67,7 +67,7 @@ const webpackConfig = merge(baseWebpackConfig, {
     new HtmlWebpackPlugin({
       template: './<%= MAIN_SRC_DIR %>index.html',
       chunks: ['vendors', 'main', 'global'],
-      chunksSortMode: 'auto',
+      chunksSortMode: 'manual',
       inject: true,
       minify: {
         removeComments: true,


### PR DESCRIPTION
This aligns the chunk sort order with devlopment profile, such that custom css is loaded also in prod mode.

closes #610

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/jhipster-vuejs/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-vuejs/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
