### PR TITLE
update frontend dependencies

### DIFF
--- a/generators/client/templates/vue/package.json.ejs
+++ b/generators/client/templates/vue/package.json.ejs
@@ -31,13 +31,13 @@ limitations under the License.
     "@fortawesome/free-solid-svg-icons": "5.13.0",
     "@fortawesome/vue-fontawesome": "0.1.9",
     "axios": "0.19.2",
-    "bootstrap": "4.4.1",
-    "bootstrap-vue": "2.13.0",
+    "bootstrap": "4.5.0",
+    "bootstrap-vue": "2.14.0",
     <%_ if (clientTheme !== 'none') { _%>
-    "bootswatch": "4.4.1",
+    "bootswatch": "4.5.0",
     <%_ } _%>
-    "date-fns": "2.12.0",
-    "swagger-ui-dist": "3.25.1",
+    "date-fns": "2.13.0",
+    "swagger-ui-dist": "3.25.3",
     <%_ if (websocket === 'spring-websocket') { _%>
     "sockjs-client": "1.1.4",
     "webstomp-client": "1.2.0",
@@ -45,13 +45,13 @@ limitations under the License.
     "vue": "2.6.11",
     "vue-class-component": "7.2.3",
     "vue-cookie": "1.1.4",
-    "vue-i18n": "8.17.4",
+    "vue-i18n": "8.17.6",
     "vue-infinite-loading": "2.4.5",
     "vue-property-decorator": "8.4.2",
     "vue-router": "3.1.6",
     "vue2-filters": "0.11.0",
     "vuelidate": "0.7.5",
-    "vuex": "3.3.0"
+    "vuex": "3.4.0"
   },
   "devDependencies": {
     "babel-core": "7.0.0-bridge.0",
@@ -59,19 +59,19 @@ limitations under the License.
     "@types/chai": "4.2.11",
     "@types/chai-string": "1.4.2",
 <%_ } _%>
-    "@types/jest": "25.2.1",
+    "@types/jest": "25.2.2",
 <%_ if (protractorTests) { _%>
     "@types/mocha": "7.0.2",
 <%_ } _%>
-    "@types/node": "13.13.4",
+    "@types/node": "14.0.1",
 <%_ if (protractorTests) { _%>
     "@types/selenium-webdriver": "4.0.9",
 <%_ } _%>
-    "@types/sinon": "9.0.0",
+    "@types/sinon": "9.0.1",
     "@types/vuelidate": "0.7.13",
     "@vue/cli-plugin-typescript": "4.3.1",
     "@vue/cli-service": "4.3.1",
-    "@vue/test-utils": "1.0.0",
+    "@vue/test-utils": "1.0.2",
     "autoprefixer": "9.7.6",
     "browser-sync": "2.26.7",
     "browser-sync-webpack-plugin": "2.2.2",
@@ -80,7 +80,7 @@ limitations under the License.
     "chai-as-promised": "7.1.1",
     "chai-string": "1.5.0",
 <%_ } _%>
-    "copy-webpack-plugin": "5.1.1",
+    "copy-webpack-plugin": "6.0.0",
     "css-loader": "3.5.3",
     "file-loader": "6.0.0",
     "friendly-errors-webpack-plugin": "1.7.0",
@@ -89,7 +89,7 @@ limitations under the License.
     <%_ if (!skipCommitHook) { _%>
     "husky": "4.2.5",
     <%_ } _%>
-    "jest": "25.5.4",
+    "jest": "26.0.1",
     "jest-junit": "10.0.0",
     "jest-serializer-vue": "2.0.2",
     "jest-sonar-reporter": "2.0.0",
@@ -118,17 +118,17 @@ limitations under the License.
     "sass-loader": "8.0.2",
     "sinon": "9.0.2",
     "terser-webpack-plugin": "3.0.1",
-    "ts-jest": "25.4.0",
-    "ts-loader": "7.0.2",
+    "ts-jest": "26.0.0",
+    "ts-loader": "7.0.4",
 <%_ if (protractorTests) { _%>
     "ts-node": "8.10.1",
 <%_ } _%>
-    "tslib": "1.11.1",
+    "tslib": "2.0.0",
     "tslint": "6.1.2",
     "tslint-config-prettier": "1.18.0",
     "tslint-eslint-rules": "5.4.0",
     "tslint-loader": "3.6.0",
-    "typescript": "3.8.3",
+    "typescript": "3.9.2",
     "url-loader": "4.1.0",
     "vue-jest": "3.0.5",
     "vue-loader": "15.9.2",
@@ -136,7 +136,7 @@ limitations under the License.
     "webpack": "4.43.0",
     "webpack-bundle-analyzer": "3.7.0",
     "webpack-cli": "3.3.11",
-    "webpack-dev-server": "3.10.3",
+    "webpack-dev-server": "3.11.0",
     "webpack-merge": "4.2.2"
   },
   "engines": {

--- a/generators/client/templates/vue/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/vue/webpack/webpack.common.js.ejs
@@ -88,19 +88,21 @@ module.exports = {
   },
   plugins: [
     new VueLoaderPlugin(),
-    new CopyWebpackPlugin([
-      { from: './node_modules/swagger-ui-dist/*.{js,css,html,png}', to: 'swagger-ui', flatten: true, ignore: ['index.html'] },
-      { from: './node_modules/axios/dist/axios.min.js', to: 'swagger-ui' },
-      { from: './src/main/webapp/swagger-ui/', to: 'swagger-ui' },
-      { from: './src/main/webapp/content/', to: 'content' },
-      { from: './src/main/webapp/favicon.ico', to: 'favicon.ico' },
-      {
-        from: './src/main/webapp/manifest.webapp',
-        to: 'manifest.webapp'
-      },
-      // jhipster-needle-add-assets-to-webpack - JHipster will add/remove third-party resources in this array
-      { from: './src/main/webapp/robots.txt', to: 'robots.txt' }
-    ]),
+    new CopyWebpackPlugin({
+      patterns: [
+        { from: './node_modules/swagger-ui-dist/*.{js,css,html,png}', to: 'swagger-ui', flatten: true, globOptions: { ignore: ['index.html'] } },
+        { from: './node_modules/axios/dist/axios.min.js', to: 'swagger-ui' },
+        { from: './src/main/webapp/swagger-ui/', to: 'swagger-ui' },
+        { from: './src/main/webapp/content/', to: 'content' },
+        { from: './src/main/webapp/favicon.ico', to: 'favicon.ico' },
+        {
+          from: './src/main/webapp/manifest.webapp',
+          to: 'manifest.webapp',
+        },
+        // jhipster-needle-add-assets-to-webpack - JHipster will add/remove third-party resources in this array
+        { from: './src/main/webapp/robots.txt', to: 'robots.txt' },
+      ]
+    }),
     // https://github.com/ampedandwired/html-webpack-plugin
     new HtmlWebpackPlugin({
       template: './<%= MAIN_SRC_DIR %>index.html',


### PR DESCRIPTION
Some usual updates, needed to update the copy webpack plugin configuration

```
 bootstrap              4.4.1  →   4.5.0 
 bootstrap-vue         2.13.0  →  2.14.0 
 date-fns              2.12.0  →  2.13.0 
 swagger-ui-dist       3.25.1  →  3.25.3 
 vue-i18n              8.17.4  →  8.17.6 
 vuex                   3.3.0  →   3.4.0 
 @types/jest           25.2.1  →  25.2.2 
 @types/node          13.13.4  →  14.0.1 
 @types/sinon           9.0.0  →   9.0.1 
 @vue/test-utils        1.0.0  →   1.0.2 
 copy-webpack-plugin    5.1.1  →   6.0.0 
 jest                  25.5.4  →  26.0.1 
 ts-jest               25.4.0  →  26.0.0 
 ts-loader              7.0.2  →   7.0.4 
 tslib                 1.11.1  →   2.0.0 
 typescript             3.8.3  →   3.9.2 
 webpack-dev-server    3.10.3  →  3.11.0
```

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/jhipster-vuejs/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-vuejs/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
