### PR TITLE
make baseHref configurable via html-webpack-plugin

### DIFF
--- a/generators/client/templates/vue/src/main/webapp/index.html.ejs
+++ b/generators/client/templates/vue/src/main/webapp/index.html.ejs
@@ -1,7 +1,6 @@
 <!doctype html>
 <html class="no-js" lang="<% if (enableTranslation) { %><%= nativeLanguage %><% } else { %>en<% } %>" dir="ltr">
 <head>
-    <base href="/" />
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title><%= baseName %></title>

--- a/generators/client/templates/vue/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/vue/webpack/webpack.common.js.ejs
@@ -105,6 +105,7 @@ module.exports = {
     }),
     // https://github.com/ampedandwired/html-webpack-plugin
     new HtmlWebpackPlugin({
+      base: '/',
       template: './<%= MAIN_SRC_DIR %>index.html',
       chunks: ['vendors', 'main', 'global'],
       chunksSortMode: 'manual',

--- a/generators/client/templates/vue/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/vue/webpack/webpack.prod.js.ejs
@@ -65,6 +65,7 @@ const webpackConfig = merge(baseWebpackConfig, {
     // you can customize output by editing /index.html
     // see https://github.com/ampedandwired/html-webpack-plugin
     new HtmlWebpackPlugin({
+      base: '/',
       template: './<%= MAIN_SRC_DIR %>index.html',
       chunks: ['vendors', 'main', 'global'],
       chunksSortMode: 'manual',


### PR DESCRIPTION
`html-webpack-plugin` now has support for the base href tag, but it injects an additional `<base href>` tag when configured (so we end up with two).  I removed it from `index.html` and added it to the webpack config.  

It's needed for both webpack.common.js and webpack.prod.js, if just in webpack.common.js then no tag is injected in a prod build.

Related to https://github.com/jhipster/jhipster-vuejs/commit/a08d8a64673905f9947ce2c76757f5065b3a3c79#r39287185

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/jhipster-vuejs/actions) are green
-   [x] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-vuejs/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
