### PR TITLE
optimize build time by custom terser config and little faster ts 

### DIFF
--- a/generators/client/templates/vue/package.json.ejs
+++ b/generators/client/templates/vue/package.json.ejs
@@ -36,8 +36,8 @@ limitations under the License.
     <%_ if (clientTheme !== 'none') { _%>
     "bootswatch": "4.5.0",
     <%_ } _%>
-    "date-fns": "2.13.0",
-    "swagger-ui-dist": "3.25.3",
+    "date-fns": "2.14.0",
+    "swagger-ui-dist": "3.25.4",
     <%_ if (websocket === 'spring-websocket') { _%>
     "sockjs-client": "1.1.4",
     "webstomp-client": "1.2.0",
@@ -45,10 +45,10 @@ limitations under the License.
     "vue": "2.6.11",
     "vue-class-component": "7.2.3",
     "vue-cookie": "1.1.4",
-    "vue-i18n": "8.17.6",
+    "vue-i18n": "8.17.7",
     "vue-infinite-loading": "2.4.5",
     "vue-property-decorator": "8.4.2",
-    "vue-router": "3.1.6",
+    "vue-router": "3.2.0",
     "vue2-filters": "0.11.0",
     "vuelidate": "0.7.5",
     "vuex": "3.4.0"
@@ -59,20 +59,20 @@ limitations under the License.
     "@types/chai": "4.2.11",
     "@types/chai-string": "1.4.2",
 <%_ } _%>
-    "@types/jest": "25.2.2",
+    "@types/jest": "25.2.3",
 <%_ if (protractorTests) { _%>
     "@types/mocha": "7.0.2",
 <%_ } _%>
-    "@types/node": "14.0.1",
+    "@types/node": "14.0.4",
 <%_ if (protractorTests) { _%>
     "@types/selenium-webdriver": "4.0.9",
 <%_ } _%>
-    "@types/sinon": "9.0.1",
+    "@types/sinon": "9.0.3",
     "@types/vuelidate": "0.7.13",
     "@vue/cli-plugin-typescript": "4.3.1",
     "@vue/cli-service": "4.3.1",
-    "@vue/test-utils": "1.0.2",
-    "autoprefixer": "9.7.6",
+    "@vue/test-utils": "1.0.3",
+    "autoprefixer": "9.8.0",
     "browser-sync": "2.26.7",
     "browser-sync-webpack-plugin": "2.2.2",
 <%_ if (protractorTests) { _%>
@@ -80,9 +80,10 @@ limitations under the License.
     "chai-as-promised": "7.1.1",
     "chai-string": "1.5.0",
 <%_ } _%>
-    "copy-webpack-plugin": "6.0.0",
+    "copy-webpack-plugin": "6.0.1",
     "css-loader": "3.5.3",
     "file-loader": "6.0.0",
+    "fork-ts-checker-webpack-plugin": "4.1.4",
     "friendly-errors-webpack-plugin": "1.7.0",
     "generator-jhipster-vuejs": "<%= blueprintjs.version %>",
     "html-webpack-plugin": "4.3.0",
@@ -95,7 +96,7 @@ limitations under the License.
     "jest-sonar-reporter": "2.0.0",
     "jest-vue-preprocessor": "1.7.1",
     <%_ if (!skipCommitHook) { _%>
-    "lint-staged": "10.2.2",
+    "lint-staged": "10.2.4",
     <%_ } _%>
     "merge-jsons-webpack-plugin": "1.0.21",
 <%_ if (protractorTests) { _%>
@@ -128,13 +129,13 @@ limitations under the License.
     "tslint-config-prettier": "1.18.0",
     "tslint-eslint-rules": "5.4.0",
     "tslint-loader": "3.6.0",
-    "typescript": "3.9.2",
+    "typescript": "3.9.3",
     "url-loader": "4.1.0",
     "vue-jest": "3.0.5",
     "vue-loader": "15.9.2",
     "vue-template-compiler": "2.6.11",
     "webpack": "4.43.0",
-    "webpack-bundle-analyzer": "3.7.0",
+    "webpack-bundle-analyzer": "3.8.0",
     "webpack-cli": "3.3.11",
     "webpack-dev-server": "3.11.0",
     "webpack-merge": "4.2.2"

--- a/generators/client/templates/vue/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/vue/webpack/webpack.common.js.ejs
@@ -39,7 +39,8 @@ module.exports = {
             loader: 'ts-loader',
             options: {
               appendTsSuffixTo: ['\\.vue$'],
-              happyPackMode: false
+              happyPackMode: true,
+              transpileOnly: true
             }
           }
         ],

--- a/generators/client/templates/vue/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/vue/webpack/webpack.prod.js.ejs
@@ -8,6 +8,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const jhiUtils = require('./utils.js');
 
 const env = require('../config/prod.env');
@@ -49,8 +50,38 @@ const webpackConfig = merge(baseWebpackConfig, {
     }),
     new TerserPlugin({
       terserOptions: {
-        warnings: false,
+        compress: {
+          arrows: false,
+          collapse_vars: false,
+          comparisons: false,
+          computed_props: false,
+          hoist_funs: false,
+          hoist_props: false,
+          hoist_vars: false,
+          inline: false,
+          loops: false,
+          negate_iife: false,
+          properties: false,
+          reduce_funcs: false,
+          reduce_vars: false,
+          switches: false,
+          toplevel: false,
+          typeofs: false,
+          booleans: true,
+          if_return: true,
+          sequences: true,
+          unused: true,
+          conditionals: true,
+          dead_code: true,
+          evaluate: true
+        },
+        mangle: {
+          safari10: true
+        }
       },
+      cache: true,
+      parallel: true,
+      extractComments: false,
       sourceMap: config.build.productionSourceMap,
     }),
     // extract css into its own file
@@ -79,7 +110,18 @@ const webpackConfig = merge(baseWebpackConfig, {
       },
     }),
     // keep module.id stable when vendor modules does not change
-    new webpack.HashedModuleIdsPlugin()
+    new webpack.HashedModuleIdsPlugin(),
+    new ForkTsCheckerWebpackPlugin(
+      {
+        vue: {
+          enabled: true,
+          compiler: 'vue-template-compiler'
+        },
+        tslint: false,
+        formatter: 'codeframe',
+        checkSyntacticErrors: false
+      }
+    )
   ]
 });
 


### PR DESCRIPTION
This pr improves the production build time. On my machine in the end it was ~8s faster (not much). What does it do?

* changed config for ts loader (type checking via https://github.com/TypeStrong/fork-ts-checker-webpack-plugin which is doing it async). The config is in line with the one used by vue cli
* align the terser plugin with vue cli
* regular dependency update (does not have impact on build times)

I also tried a hello world app created with vue-cli and the production build (for basically one page) takes already 4.5s on my machine, so having for a full blown app like ours taking ~16 - 17s on my machine looks at least "ok"

Not doing sourcemaps with terser plugin cuts again 3-4s from the overall build time.

updates #620

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/jhipster-vuejs/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-vuejs/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
