### PR TITLE
add websocket proxy to webpack.dev.js

### DIFF
--- a/generators/client/templates/vue/src/main/webapp/app/admin/tracker/tracker.service.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/admin/tracker/tracker.service.ts.ejs
@@ -27,8 +27,9 @@ export default class TrackerService {
     }
     // building absolute path so that websocket doesn't fail when deploying with a context path
     const loc = window.location;
+    const baseHref = document.querySelector('base').getAttribute('href');
     let url;
-    url = '//' + loc.host + loc.pathname + 'websocket/tracker';
+    url = '//' + loc.host + baseHref + 'websocket/tracker';
     <%_ if (authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
     const authToken = localStorage.getItem('<%=jhiPrefixDashed %>-authenticationToken') || sessionStorage.getItem('<%=jhiPrefixDashed %>-authenticationToken');
     if (authToken) {

--- a/generators/client/templates/vue/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/vue/webpack/webpack.dev.js.ejs
@@ -47,7 +47,16 @@ module.exports = merge(baseWebpackConfig, {
         target: 'http://127.0.0.1:<%= serverPort %>',
         secure: false,
         headers: { host: 'localhost:9000' }
+      },
+      <%_ if (websocket === 'spring-websocket') { _%>
+      {
+        context: [
+          '/websocket'
+        ],
+        target: 'ws://127.0.0.1:<%= serverPort %>',
+        ws: true
       }
+      <%_ } _%>
     ],
     watchOptions: {
       ignored: /node_modules/
@@ -66,7 +75,10 @@ module.exports = merge(baseWebpackConfig, {
         host: 'localhost',
         port: 9000,
         proxy: {
-          target: 'http://localhost:9060'
+          target: 'http://localhost:9060',
+          <%_ if (websocket === 'spring-websocket') { _%>
+          ws: true,
+          <%_ } _%>
         },
         socket: {
           clients: {


### PR DESCRIPTION
Copied the config from Angular's `webpack.dev.js`

Also fixes refreshing on the admin tracker page, similar to https://github.com/jhipster/generator-jhipster/pull/9593.  It would try to connect to `http://localhost:9000/admin/jhi-trackerwebsocket/tracker/` instead of `http://localhost:9000/websocket/tracker/`

Fix jhipster/generator-jhipster#11835

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/jhipster-vuejs/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-vuejs/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
