### PR TITLE
Fix usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ jhipster --blueprints vuejs
 To create a new Vue.js empty page, run
 
 ```bash
-jhipster --blueprint vuejs page
+jhipster --blueprints vuejs page
 ```
 
 


### PR DESCRIPTION
--blueprint is deprecated. So, changed it to --blueprints in usage documentation.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/jhipster-vuejs/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-vuejs/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
